### PR TITLE
画面が切り替わったらプレイヤーが移動しないように調整

### DIFF
--- a/backend/src/game_engine/services/mapService.ts
+++ b/backend/src/game_engine/services/mapService.ts
@@ -72,8 +72,8 @@ export default class MapService {
     return Matter.Bodies.rectangle(
       tileWidth / 2 + tileWidth * x,
       Constants.HEADER_HEIGHT + tileHeight / 2 + tileHeight * y,
-      tileWidth,
-      tileHeight,
+      tileWidth * 0.9,
+      tileHeight * 0.9,
       {
         isStatic: true,
         label: Constants.OBJECT_LABEL.BLOCK,

--- a/backend/src/game_engine/services/playerService.ts
+++ b/backend/src/game_engine/services/playerService.ts
@@ -50,18 +50,21 @@ export default class PlayerService {
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     while ((data = player.inputQueue.shift())) {
-      let newVx = data.x - player.x;
-      let newVy = data.y - player.y;
+      const { player: playerData, isInput } = data;
 
-      if (Math.abs(newVx) > velocity) newVx = velocity * Math.sign(newVx);
-      if (Math.abs(newVy) > velocity) newVy = velocity * Math.sign(newVy);
+      if (isInput === false) {
+        Matter.Body.setVelocity(playerBody, { x: 0, y: 0 });
+      } else {
+        let newVx = playerData.x - player.x;
+        let newVy = playerData.y - player.y;
 
-      newVx = Math.floor(newVx);
-      newVy = Math.floor(newVy);
+        if (Math.abs(newVx) > velocity) newVx = velocity * Math.sign(newVx);
+        if (Math.abs(newVy) > velocity) newVy = velocity * Math.sign(newVy);
 
-      Matter.Body.setVelocity(playerBody, { x: newVx, y: newVy });
+        Matter.Body.setVelocity(playerBody, { x: newVx, y: newVy });
+      }
 
-      playerState.frameKey = data.frameKey;
+      playerState.frameKey = playerData.frameKey;
     }
   }
 

--- a/frontend/src/characters/MyPlayer.ts
+++ b/frontend/src/characters/MyPlayer.ts
@@ -42,25 +42,33 @@ export default class MyPlayer extends Player {
     this.inputPayload.up = cursorKeys.up.isDown || cursorKeys.W.isDown;
     this.inputPayload.down = cursorKeys.down.isDown || cursorKeys.S.isDown;
 
+    const isInput =
+      (this.inputPayload.left ||
+        this.inputPayload.right ||
+        this.inputPayload.up ||
+        this.inputPayload.down) &&
+      !document.hidden;
+
     let vx = 0; // velocity x
     let vy = 0; // velocity y
 
-    const velocity = this.getSpeed();
-    if (this.inputPayload.left) {
-      vx -= velocity;
-    } else if (this.inputPayload.right) {
-      vx += velocity;
-    }
+    if (isInput) {
+      const velocity = this.getSpeed();
+      if (this.inputPayload.left) {
+        vx -= velocity;
+      } else if (this.inputPayload.right) {
+        vx += velocity;
+      }
 
-    if (this.inputPayload.up) {
-      vy -= velocity;
-    } else if (this.inputPayload.down) {
-      vy += velocity;
+      if (this.inputPayload.up) {
+        vy -= velocity;
+      } else if (this.inputPayload.down) {
+        vy += velocity;
+      }
     }
 
     this.setVelocity(vx, vy);
-
-    network.sendPlayerMove(this);
+    network.sendPlayerMove(this, isInput);
 
     if (vx > 0) this.play('player_right', true);
     else if (vx < 0) this.play('player_left', true);

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -96,8 +96,8 @@ export default class Network {
   }
 
   // 自分のプレイヤー動作を送る
-  sendPlayerMove(player: MyPlayer) {
-    this.room?.send(Constants.NOTIFICATION_TYPE.PLAYER_MOVE, player);
+  sendPlayerMove(player: MyPlayer, isInput: boolean) {
+    this.room?.send(Constants.NOTIFICATION_TYPE.PLAYER_MOVE, { player, isInput });
   }
 
   // 自分の爆弾を送る


### PR DESCRIPTION
- #125 
現状動作キーを押していない状態で画面を切り替えると正常な動きだが、動作キーを押したまま画面を切り替えるとプレイヤーがサーバで停止するまでに一秒ほどの遅れが生じる。まだ修正は必要ですが、一旦プルリク出します。