### PR TITLE
アイテムの作成・削除をサーバで行い、ステータスアップもさせた

### DIFF
--- a/backend/src/game_engine/collision_handler/collision_handler.ts
+++ b/backend/src/game_engine/collision_handler/collision_handler.ts
@@ -29,7 +29,6 @@ export default function collisionHandler(
 
   // // PLAYER & ITEM
   if (isPlayer && isItem) {
-    console.log('player hit item');
     const playerBody = labelA === Constants.OBJECT_LABEL.PLAYER ? bodyA : bodyB;
     const itemBody = labelA === Constants.OBJECT_LABEL.ITEM ? bodyA : bodyB;
     const sessionId = engine.sessionIdByBodyId.get(playerBody.id);

--- a/backend/src/game_engine/collision_handler/player.ts
+++ b/backend/src/game_engine/collision_handler/player.ts
@@ -20,9 +20,5 @@ export function playerToItem(player: PlayerInterface, item: ItemInterface, engin
 
     default:
   }
-  if (engine === undefined) {
-    item.removeItem();
-  } else {
-    engine?.itemService.removeItem(item as Item);
-  }
+  engine?.itemService.removeItem(item as Item);
 }

--- a/backend/src/game_engine/services/ItemService.ts
+++ b/backend/src/game_engine/services/ItemService.ts
@@ -36,5 +36,6 @@ export default class ItemService {
     Matter.Composite.remove(this.gameEngine.world, itemBody);
     this.gameEngine.itemBodies.delete(item.id);
     this.gameEngine.itemIdByBodyId.delete(itemBody.id);
+    this.gameEngine.state.items.delete(item.id);
   }
 }

--- a/backend/src/game_engine/services/mapService.ts
+++ b/backend/src/game_engine/services/mapService.ts
@@ -129,6 +129,7 @@ export default class MapService {
     if (block.itemType !== undefined) {
       const item = new Item(block.x, block.y, block.itemType);
       this.gameEngine.itemService.addItem(item);
+      this.gameEngine.state.items.set(item.id, item);
     }
   }
 }

--- a/backend/src/rooms/schema/Player.ts
+++ b/backend/src/rooms/schema/Player.ts
@@ -125,18 +125,27 @@ export default class Player extends Schema {
   }
 
   // ボムを置ける最大数を増やす
-  recoverSettableBombCount() {
-    this.settableBombCount++;
+  recoverSettableBombCount(count = 1) {
+    this.settableBombCount += count;
   }
 
   // 現在設置しているボムの数を減らす
-  consumeCurrentSetBombCount() {
-    this.settableBombCount--;
+  consumeCurrentSetBombCount(count = 1) {
+    this.settableBombCount -= count;
   }
 
   // ボムの最大数を増やす
-  increaseMaxBombCount() {
-    // TODO: not implemented
-    console.log('increaseMaxBombCount');
+  increaseMaxBombCount(count = 1) {
+    const oldMaxBombCount = this.maxBombCount;
+    if (this.maxBombCount + count > Constants.MAX_SETTABLE_BOMB_COUNT) {
+      this.maxBombCount = Constants.MAX_SETTABLE_BOMB_COUNT;
+    } else {
+      this.maxBombCount += count;
+    }
+
+    // ボムの最大数が増えた場合は、今設置できるボムの数も増やす
+    if (oldMaxBombCount < this.maxBombCount) {
+      this.recoverSettableBombCount(this.maxBombCount - oldMaxBombCount);
+    }
   }
 }

--- a/frontend/src/characters/MyPlayer.ts
+++ b/frontend/src/characters/MyPlayer.ts
@@ -1,11 +1,12 @@
 import Phaser from 'phaser';
 
 import * as Constants from '../../../backend/src/constants/constants';
-import Player from './Player';
 import ServerPlayer from '../../../backend/src/rooms/schema/Player';
-import { NavKeys } from '../types/keyboard';
 import Network from '../services/Network';
+import { NavKeys } from '../types/keyboard';
 import { getGameScene } from '../utils/globalGame';
+import Player from './Player';
+
 export default class MyPlayer extends Player {
   private readonly remoteRef: Phaser.GameObjects.Rectangle;
 
@@ -36,6 +37,9 @@ export default class MyPlayer extends Player {
     this.updateRemoteRef(player);
     this.forceMovePlayerPosition(player);
     this.setHP(player.hp);
+    this.setSpeed(player.speed);
+    this.setBombStrength(player.bombStrength);
+    this.setMaxBombCount(player.maxBombCount);
     if (this.isDead()) this.died();
   }
 

--- a/frontend/src/characters/OtherPlayer.ts
+++ b/frontend/src/characters/OtherPlayer.ts
@@ -1,5 +1,5 @@
-import Player from './Player';
 import ServerPlayer from '../../../backend/src/rooms/schema/Player';
+import Player from './Player';
 
 export default class OtherPlayer extends Player {
   private serverX: number;
@@ -30,6 +30,8 @@ export default class OtherPlayer extends Player {
     this.serverY = serverPlayer.y;
     this.frameKey = serverPlayer.frameKey;
     this.setHP(serverPlayer.hp);
+    this.setSpeed(serverPlayer.speed);
+    this.setBombStrength(serverPlayer.bombStrength);
 
     if (this.isDead()) {
       this.died();

--- a/frontend/src/characters/Player.ts
+++ b/frontend/src/characters/Player.ts
@@ -129,10 +129,17 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     this.tint = color;
   }
 
-  increaseMaxBombCount() {
-    if (this.maxBombCount < Constants.MAX_SETTABLE_BOMB_COUNT) {
-      this.maxBombCount++;
-      this.settableBombCount++;
+  // 最大設置可能なボムの数を設定する
+  setMaxBombCount(maxBombCount: number) {
+    const oldMaxBombCount = this.maxBombCount;
+    if (maxBombCount > Constants.MAX_SETTABLE_BOMB_COUNT) {
+      maxBombCount = Constants.MAX_SETTABLE_BOMB_COUNT;
+    }
+    this.maxBombCount = maxBombCount;
+
+    // ボムの最大数が増えた場合は、設置できるボムの数も増やす
+    if (oldMaxBombCount < this.maxBombCount) {
+      this.recoverSettableBombCount(this.maxBombCount - oldMaxBombCount);
     }
   }
 
@@ -140,14 +147,18 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     return this.settableBombCount;
   }
 
-  // ボムを置ける最大数を増やす
-  recoverSettableBombCount() {
-    this.settableBombCount++;
+  // 今設置できるボムの数を回復する
+  recoverSettableBombCount(count = 1) {
+    if (this.settableBombCount + count > this.maxBombCount) {
+      this.settableBombCount = this.maxBombCount;
+    } else {
+      this.settableBombCount += count;
+    }
   }
 
-  // 現在設置しているボムの数を減らす
-  consumeSettableBombCount() {
-    this.settableBombCount--;
+  // 今設置できるボムの数を減らす
+  consumeSettableBombCount(count = 1) {
+    this.settableBombCount -= count;
   }
 
   // 死亡

--- a/frontend/src/characters/Player.ts
+++ b/frontend/src/characters/Player.ts
@@ -143,7 +143,7 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     }
   }
 
-  getSettableBombCount() {
+  getSettableBombCount(): number {
     return this.settableBombCount;
   }
 
@@ -172,6 +172,21 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
 
   isEqualSessionId(sessionId: string): boolean {
     return this.sessionId === sessionId;
+  }
+
+  // ボム増加アイテムを取得した数
+  getItemCountOfBombCount(): number {
+    return this.maxBombCount - Constants.INITIAL_SETTABLE_BOMB_COUNT;
+  }
+
+  // 爆弾の破壊力アイテムを取得した数
+  getItemCountOfBombStrength(): number {
+    return this.bombStrength - Constants.INITIAL_BOMB_STRENGTH;
+  }
+
+  // 速さアイテムを取得した数
+  getItemCountOfSpeed(): number {
+    return this.speed - Constants.INITIAL_PLAYER_SPEED;
   }
 
   private animationFlash(duration: number) {

--- a/frontend/src/events/GameEvents.ts
+++ b/frontend/src/events/GameEvents.ts
@@ -8,4 +8,6 @@ export enum Event {
   GAME_STATE_UPDATED = 'game-state-updated',
   BOMB_ADDED = 'bomb-added',
   BLOCKS_REMOVED = 'blocks-removed',
+  ITEM_ADDED = 'item-added',
+  ITEM_REMOVED = 'item-removed',
 }

--- a/frontend/src/game_engine/collision_handler/collision_handler.ts
+++ b/frontend/src/game_engine/collision_handler/collision_handler.ts
@@ -1,9 +1,6 @@
 import * as Constants from '../../../../backend/src/constants/constants';
 import { blastToBomb } from '../../../../backend/src/game_engine/collision_handler/blast';
-import { playerToItem } from '../../../../backend/src/game_engine/collision_handler/player';
-import MyPlayer from '../../characters/MyPlayer';
 import Bomb from '../../items/Bomb';
-import Item from '../../items/Item';
 
 export default function collisionHandler(bodyA: MatterJS.BodyType, bodyB: MatterJS.BodyType) {
   /**
@@ -17,17 +14,11 @@ export default function collisionHandler(bodyA: MatterJS.BodyType, bodyB: Matter
   const aType = bodyA.label as Constants.OBJECT_LABELS;
   const bType = bodyB.label as Constants.OBJECT_LABELS;
 
-  // A = PLAYER, B = ITEM
-  if (aType === Constants.OBJECT_LABEL.PLAYER && bType === Constants.OBJECT_LABEL.ITEM) {
-    const player = bodyA.gameObject as MyPlayer;
-    const item = bodyB.gameObject as Item;
-    playerToItem(player, item);
-  }
   // A = PLAYER, B = BLAST
   // サーバで判定するので不要
 
   // A = BLAST, B = BOMB
-  else if (aType === Constants.OBJECT_LABEL.BLAST && bType === Constants.OBJECT_LABEL.BOMB) {
+  if (aType === Constants.OBJECT_LABEL.BLAST && bType === Constants.OBJECT_LABEL.BOMB) {
     blastToBomb(bodyB.gameObject as Bomb);
   }
 }

--- a/frontend/src/items/Bomb.ts
+++ b/frontend/src/items/Bomb.ts
@@ -8,8 +8,8 @@ import collisionHandler from '../game_engine/collision_handler/collision_handler
 import { phaserGlobalGameObject } from '../PhaserGame';
 import Game from '../scenes/Game';
 import { getDimensionalMap, getHighestPriorityFromBodies } from '../services/Map';
-import { getDepth } from './util';
 import { getGameScene } from '../utils/globalGame';
+import { getDepth } from './util';
 
 export default class Bomb extends Phaser.Physics.Matter.Sprite {
   private readonly bombStrength: number;
@@ -364,10 +364,6 @@ Phaser.GameObjects.GameObjectFactory.register(
 );
 
 export interface PlayerInterface {
-  setBombStrength: (bombStrength: number) => void;
-  increaseMaxBombCount: () => void;
   recoverSettableBombCount: () => void;
-  consumeSettableBombCount: () => void;
-  canSetBomb: (mp: Phaser.Physics.Matter.MatterPhysics) => boolean;
   isEqualSessionId: (sessionId: string) => boolean;
 }

--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -42,11 +42,12 @@ export default class Game extends Phaser.Scene {
   private elapsedTime: number = 0; // 経過時間
   private readonly fixedTimeStep: number = Constants.FRAME_RATE; // 1フレームの経過時間
   private currBlocks?: Map<string, Block>; // 現在存在しているブロック
-  private currItems?: Map<string, Item>; // 現在存在しているアイテム
+  private readonly currItems: Map<string, Item>; // 現在存在しているアイテム
   private bgm?: Phaser.Sound.BaseSound;
 
   constructor() {
     super(Config.SCENE_NAME_GAME);
+    this.currItems = new Map();
   }
 
   init() {
@@ -210,16 +211,16 @@ export default class Game extends Phaser.Scene {
   private handleItemAdded(serverItem: ServerItem) {
     if (serverItem === undefined) return;
     const item = this.add.item(serverItem.x, serverItem.y, serverItem.itemType);
-    this.currItems = this.currItems?.set(serverItem.id, item);
+    this.currItems.set(serverItem.id, item);
   }
 
   // アイテムが破壊・習得されたらアイテムを削除する
   private handleItemRemoved(data: any) {
     const { id } = data;
-    const itemBody = this.currItems?.get(id);
+    const itemBody = this.currItems.get(id);
     if (itemBody === undefined) return;
-    this.currItems?.delete(id);
-    itemBody.destroy();
+    this.currItems.delete(id);
+    itemBody.removeItem();
   }
 
   // ボム設置後、プレイヤーの挙動によってボムの衝突判定を更新する

--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -157,7 +157,7 @@ export default class Game extends Phaser.Scene {
     const header = this.scene.get(Config.SCENE_NAME_GAME_HEADER) as GameHeader;
     data.forEach((v: any) => {
       if (v.field === 'now') this.setServerTime(v.value);
-      if (v.field === 'remainTime') header.updateTimerText(v.value);
+      if (v.field === 'remainTime') header.updateTextTimer(v.value);
     });
   }
 

--- a/frontend/src/scenes/GameHeader.ts
+++ b/frontend/src/scenes/GameHeader.ts
@@ -1,16 +1,22 @@
 import Phaser from 'phaser';
 
 import * as Constants from '../../../backend/src/constants/constants';
+import MyPlayer from '../characters/MyPlayer';
 import * as Config from '../config/config';
-import convertSecondsToMMSS from '../utils/timer';
 import ToString from '../utils/color';
+import { getGameScene } from '../utils/globalGame';
+import convertSecondsToMMSS from '../utils/timer';
 
 export default class GameHeader extends Phaser.Scene {
   private readonly width: number;
   private readonly height: number;
 
-  private timerText!: Phaser.GameObjects.Text;
+  private textTimer!: Phaser.GameObjects.Text;
   private remainTime: number = 0;
+  private player!: MyPlayer;
+  private textBombCount!: Phaser.GameObjects.Text;
+  private textBombStrength!: Phaser.GameObjects.Text;
+  private textSpeed!: Phaser.GameObjects.Text;
 
   constructor() {
     super(Config.SCENE_NAME_GAME_HEADER);
@@ -20,21 +26,43 @@ export default class GameHeader extends Phaser.Scene {
   }
 
   init() {
-    // Header の timer のテキスト
-    const fontSize = 32;
-    const paddingHeight = (this.height - fontSize) / 2;
-
-    this.timerText = this.add
-      .text(0, 0, '', { fontSize: `${fontSize}px` })
-      .setColor(ToString(Constants.HEADER_TIMER_TEXT_COLOR_CODE))
-      .setPadding(10, paddingHeight, 10, paddingHeight);
-
     this.cameras.main.setSize(this.width, this.height);
     this.cameras.main.setBackgroundColor(ToString(Constants.HEADER_COLOR_CODE));
+
+    this.player = getGameScene().getCurrentPlayer();
+
+    this.textTimer = this.createText(0, 0, '');
+    this.textBombCount = this.createText(200, 0, `×${this.player.getItemCountOfBombCount()}`);
+    this.textBombStrength = this.createText(350, 0, `×${this.player.getItemCountOfBombStrength()}`);
+    this.textSpeed = this.createText(500, 0, `×${this.player.getItemCountOfSpeed()}`);
+
+    // 特に意味はないが Container でまとめておく
+    this.add.container(0, 0, [
+      this.add.image(150, 10, Constants.ITEM_TYPE.BOMB_POSSESSION_UP).setScale(0.5).setOrigin(0, 0),
+      this.textBombCount,
+      this.add.image(300, 10, Constants.ITEM_TYPE.BOMB_STRENGTH).setScale(0.5).setOrigin(0, 0),
+      this.textBombStrength,
+      this.add.image(450, 10, Constants.ITEM_TYPE.PLAYER_SPEED).setScale(0.5).setOrigin(0, 0),
+      this.textSpeed,
+    ]);
   }
 
-  updateTimerText(timeLimit: number) {
+  update() {
+    this.textBombCount.setText(`×${this.player.getItemCountOfBombCount()}`);
+    this.textBombStrength.setText(`×${this.player.getItemCountOfBombStrength()}`);
+    this.textSpeed.setText(`×${this.player.getItemCountOfSpeed()}`);
+  }
+
+  updateTextTimer(timeLimit: number) {
     this.remainTime = timeLimit / 1000;
-    this.timerText.setText(convertSecondsToMMSS(this.remainTime));
+    this.textTimer.setText(convertSecondsToMMSS(this.remainTime));
+  }
+
+  createText(x: number, y: number, text: string, fontSize = 32): Phaser.GameObjects.Text {
+    const paddingHeight = (this.height - fontSize) / 2;
+    return this.add
+      .text(x, y, text, { fontSize: `${fontSize}px` })
+      .setColor(ToString(Constants.HEADER_TIMER_TEXT_COLOR_CODE))
+      .setPadding(10, paddingHeight, 10, paddingHeight);
   }
 }

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -3,6 +3,7 @@ import GameRoomState from '../../../backend/src/rooms/schema/GameRoomState';
 import * as Config from '../config/config';
 import * as Constants from '../../../backend/src/constants/constants';
 import ServerPlayer from '../../../backend/src/rooms/schema/Player';
+import ServerItem from '../../../backend/src/rooms/schema/Item';
 import { Bomb as ServerBomb } from '../../../backend/src/rooms/schema/Bomb';
 import { gameEvents, Event } from '../events/GameEvents';
 import MyPlayer from '../characters/MyPlayer';
@@ -67,6 +68,14 @@ export default class Network {
     this.room.state.blocks.onRemove = (data: any) => {
       gameEvents.emit(Event.BLOCKS_REMOVED, data);
     };
+
+    this.room.state.items.onAdd = (data: any) => {
+      gameEvents.emit(Event.ITEM_ADDED, data);
+    };
+
+    this.room.state.items.onRemove = (data: any) => {
+      gameEvents.emit(Event.ITEM_REMOVED, data);
+    };
   }
 
   // 自分がルームに参加した時
@@ -102,6 +111,15 @@ export default class Network {
   // blocks が消去（破壊）された時
   onBlocksRemoved(callback: (data: any) => void, context?: any) {
     gameEvents.on(Event.BLOCKS_REMOVED, callback, context);
+  }
+
+  onItemAdded(callback: (item: ServerItem) => void, context?: any) {
+    gameEvents.on(Event.ITEM_ADDED, callback, context);
+  }
+
+  // item が消去（破壊）された時
+  onItemRemoved(callback: (data: any) => void, context?: any) {
+    gameEvents.on(Event.ITEM_REMOVED, callback, context);
   }
 
   // 自分のプレイヤー動作を送る


### PR DESCRIPTION
- fixed #149 

以下を実装

- アイテムの作成・削除をサーバで行う
- 取得判定をサーバのみにした
- アイテムの取得結果の反映を追加
- header に取得したアイテムを追加

https://user-images.githubusercontent.com/10017674/211362929-05443404-c7f3-43bb-8e81-570ce8093518.mov


