### PR TITLE
サーバ側のアイテムのサイズをクライアントに寄せた

### DIFF
--- a/backend/src/game_engine/services/ItemService.ts
+++ b/backend/src/game_engine/services/ItemService.ts
@@ -16,8 +16,8 @@ export default class ItemService {
     const itemBody = Matter.Bodies.rectangle(
       item.x,
       item.y,
-      Constants.TILE_WIDTH,
-      Constants.TILE_HEIGHT,
+      Constants.TILE_WIDTH * 0.675,
+      Constants.TILE_HEIGHT * 0.675,
       {
         label: Constants.OBJECT_LABEL.ITEM,
         isSensor: true,


### PR DESCRIPTION
サーバにおけるアイテムサイズが大きすぎて、
そのマスを通らなくてもアイテムが手に入ってしまうのでクライアントに寄せました。

クライアントが 96px ✖️ 0.45 = 43.2 
サーバが 64 ✖️ 0.675 = 43.2
