### PR TITLE
ブロックの削除タイミングをサバクラで同期する

### DIFF
--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -15,6 +15,8 @@ export const FRAME_RATE = 1000 / FPS; // 1 frame にかかる時間(ms)
 // オブジェクト生成時の遅延時間
 // クライアントとサーバの同期を取るために、オブジェクト生成時に遅延を入れています。
 export const OBJECT_CREATION_DELAY = 100; // ms
+// オブジェクト削除時の遅延時間
+export const OBJECT_REMOVAL_DELAY = 100; // ms
 
 // Dockerfile の中と、デプロイ時にポートを指定しているので、ここの設定は開発時にしか利用されません。
 export const SERVER_LISTEN_PORT = 2567;

--- a/backend/src/game_engine/collision_handler/collision_handler.ts
+++ b/backend/src/game_engine/collision_handler/collision_handler.ts
@@ -72,6 +72,9 @@ export default function collisionHandler(
     const blockId = blockBody.id.toString();
     const block = engine.state.blocks.get(blockId);
     if (block === undefined) return;
-    engine.mapService.destroyBlock(block);
+
+    // クライアントと同期をとって消すため、ここでは削除の時間を決めるだけにする
+    block.removedAt = Date.now() + Constants.OBJECT_REMOVAL_DELAY;
+    engine.state.getBlockToDestroyQueue().enqueue(block);
   }
 }

--- a/backend/src/rooms/GameRoom.ts
+++ b/backend/src/rooms/GameRoom.ts
@@ -4,6 +4,7 @@ import Matter from 'matter-js';
 import * as Constants from '../constants/constants';
 import GameEngine from './GameEngine';
 import { Bomb } from './schema/Bomb';
+import Block from './schema/Block';
 import GameRoomState from './schema/GameRoomState';
 import PlacementObjectInterface from '../interfaces/placement_object';
 import GameQueue from '../utils/gameQueue';
@@ -80,6 +81,11 @@ export default class GameRoom extends Room<GameRoomState> {
           this.removeBombEvent(bomb)
         );
 
+        // ブロックの処理
+        this.objectRemoveHandler(this.state.getBlockToDestroyQueue(), (block) =>
+          this.removeBlockEvent(block)
+        );
+
         // ゲーム終了判定 TODO: ロビーができて、ちゃんとゲーム開始判定ができたら有効化する
         // if (
         //   this.state.gameState.isPlaying() &&
@@ -142,6 +148,13 @@ export default class GameRoom extends Room<GameRoomState> {
     this.state.getBombToExplodeQueue().dequeue();
     this.engine.bombService.explode(bomb);
     this.state.deleteBomb(bomb);
+  }
+
+  // 爆弾削除のイべント
+  private removeBlockEvent(b: PlacementObjectInterface) {
+    const block = b as Block;
+    this.state.getBombToExplodeQueue().dequeue();
+    this.engine.mapService.destroyBlock(block);
   }
 
   /*

--- a/backend/src/rooms/schema/Block.ts
+++ b/backend/src/rooms/schema/Block.ts
@@ -15,11 +15,28 @@ export default class Block extends Schema {
   @type('string')
   itemType?: Constants.ITEM_TYPES;
 
+  @type('number')
+  createdAt: number;
+
+  // ブロックが破壊される時間
+  @type('number')
+  removedAt: number;
+
   constructor(id: string, x: number, y: number, itemType?: Constants.ITEM_TYPES) {
     super();
     this.id = id;
     this.x = x;
     this.y = y;
     this.itemType = itemType;
+    this.createdAt = Date.now();
+    this.removedAt = Infinity;
+  }
+
+  isCreatedTime(): boolean {
+    return this.createdAt <= Date.now();
+  }
+
+  isRemovedTime(): boolean {
+    return this.removedAt <= Date.now();
   }
 }

--- a/backend/src/rooms/schema/GameRoomState.ts
+++ b/backend/src/rooms/schema/GameRoomState.ts
@@ -27,6 +27,8 @@ export default class GameRoomState extends Schema {
   private readonly bombToCreateQueue: GameQueue<Bomb> = new GameQueue<Bomb>();
   // 爆弾を爆発させるキュー
   private readonly bombToExplodeQueue: GameQueue<Bomb> = new GameQueue<Bomb>();
+  // ブロックを破壊するキュー
+  private readonly blockToDestroyQueue: GameQueue<Block> = new GameQueue<Block>();
 
   @type(Map) gameMap = new Map();
 
@@ -69,6 +71,10 @@ export default class GameRoomState extends Schema {
 
   getBombToExplodeQueue(): GameQueue<Bomb> {
     return this.bombToExplodeQueue;
+  }
+
+  getBlockToDestroyQueue(): GameQueue<Block> {
+    return this.blockToDestroyQueue;
   }
 
   createItem(x: number, y: number, itemType: ITEM_TYPES) {

--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -18,6 +18,7 @@ import * as Constants from '../../../backend/src/constants/constants';
 import ServerPlayer from '../../../backend/src/rooms/schema/Player';
 import { Bomb as ServerBomb } from '../../../backend/src/rooms/schema/Bomb';
 import ServerItem from '../../../backend/src/rooms/schema/Item';
+import ServerBlock from '../../../backend/src/rooms/schema/Block';
 import GameRoomState from '../../../backend/src/rooms/schema/GameRoomState';
 import Bomb from '../items/Bomb';
 import Item from '../items/Item';
@@ -30,6 +31,7 @@ import phaserJuice from '../lib/phaserJuice';
 import GameQueue from '../../../backend/src/utils/gameQueue';
 import PlacementObjectInterface from '../../../backend/src/interfaces/placement_object';
 import { createBomb } from '../services/Bomb';
+import { removeBlock } from '../services/Block';
 
 export default class Game extends Phaser.Scene {
   private network!: Network;
@@ -46,6 +48,7 @@ export default class Game extends Phaser.Scene {
   private readonly fixedTimeStep: number = Constants.FRAME_RATE; // 1フレームの経過時間
   private currBlocks?: Map<string, Block>; // 現在存在しているブロック
   private readonly bombToCreateQueue: GameQueue<ServerBomb> = new GameQueue<ServerBomb>();
+  private readonly blockToRemoveQueue: GameQueue<ServerBlock> = new GameQueue<ServerBlock>();
   private readonly currItems: Map<string, Item>; // 現在存在しているアイテム
   private bgm?: Phaser.Sound.BaseSound;
   private readonly juice: phaserJuice;
@@ -112,6 +115,7 @@ export default class Game extends Phaser.Scene {
     this.placeObjectFromQueue(this.bombToCreateQueue, (v: PlacementObjectInterface) =>
       createBomb(v)
     );
+    this.removeObjectFromQueue(this.blockToRemoveQueue, (v: ServerBlock) => removeBlock(v));
     this.updateBombCollision();
   }
 
@@ -189,24 +193,11 @@ export default class Game extends Phaser.Scene {
     this.bombToCreateQueue.enqueue(serverBomb);
   }
 
-  // 破壊されたブロックにアイテムタイプがあればアイテムを追加する。
-  private handleBlocksRemoved(data: any) {
-    const { id } = data;
-    const blockBody = this.currBlocks?.get(id);
+  // 破壊予定のブロックをキューに入れる
+  private handleBlocksRemoved(serverBlock: ServerBlock) {
+    const blockBody = this.currBlocks?.get(serverBlock.id);
     if (blockBody === undefined) return;
-    this.currBlocks?.delete(id);
-
-    const juice = this.juice;
-
-    // ブロック破壊のアニメーション
-    const timer = setInterval(() => {
-      juice.flash(blockBody, 30, Constants.RED.toString());
-    }, 30);
-
-    setTimeout(() => {
-      clearInterval(timer);
-      blockBody.destroy();
-    }, 500);
+    this.blockToRemoveQueue.enqueue(serverBlock);
   }
 
   // アイテム追加イベント時に、マップにアイテムを追加
@@ -232,6 +223,18 @@ export default class Game extends Phaser.Scene {
     const data = queue.read();
     if (data === undefined) return;
     if (data.createdAt >= this.serverTime) {
+      callback(data);
+      queue.dequeue();
+    }
+  }
+
+  // キューに溜まっているオブジェクトをマップから削除する
+  private removeObjectFromQueue(queue: GameQueue<PlacementObjectInterface>, callback: Function) {
+    if (queue.isEmpty()) return;
+
+    const data = queue.read();
+    if (data === undefined) return;
+    if (data.removedAt <= this.serverTime) {
       callback(data);
       queue.dequeue();
     }
@@ -292,5 +295,9 @@ export default class Game extends Phaser.Scene {
 
   public getJuice(): phaserJuice {
     return this.juice;
+  }
+
+  public getCurrBlocks(): Map<string, Block> | undefined {
+    return this.currBlocks;
   }
 }

--- a/frontend/src/services/Block.ts
+++ b/frontend/src/services/Block.ts
@@ -1,0 +1,27 @@
+import ServerBlock from '../../../backend/src/rooms/schema/Block';
+import { getGameScene } from '../utils/globalGame';
+import * as Constants from '../../../backend/src/constants/constants';
+
+export function removeBlock(block: ServerBlock) {
+  const game = getGameScene();
+  const id = block.id;
+
+  const currBlocks = game.getCurrBlocks();
+  if (currBlocks === undefined) return;
+
+  const blockBody = currBlocks.get(id);
+  if (blockBody === undefined) return;
+  currBlocks.delete(id);
+
+  const juice = game.getJuice();
+
+  // ブロック破壊のアニメーション
+  const timer = setInterval(() => {
+    juice.flash(blockBody, 30, Constants.RED.toString());
+  }, 30);
+
+  setTimeout(() => {
+    clearInterval(timer);
+    blockBody.destroy();
+  }, 500);
+}

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -4,6 +4,7 @@ import * as Config from '../config/config';
 import * as Constants from '../../../backend/src/constants/constants';
 import ServerPlayer from '../../../backend/src/rooms/schema/Player';
 import ServerItem from '../../../backend/src/rooms/schema/Item';
+import ServerBlock from '../../../backend/src/rooms/schema/Block';
 import { Bomb as ServerBomb } from '../../../backend/src/rooms/schema/Bomb';
 import { gameEvents, Event } from '../events/GameEvents';
 import MyPlayer from '../characters/MyPlayer';
@@ -65,7 +66,7 @@ export default class Network {
       gameEvents.emit(Event.GAME_STATE_UPDATED, data);
     };
 
-    this.room.state.blocks.onRemove = (data: any) => {
+    this.room.state.blocks.onRemove = (data: ServerBlock) => {
       gameEvents.emit(Event.BLOCKS_REMOVED, data);
     };
 
@@ -109,7 +110,7 @@ export default class Network {
   }
 
   // blocks が消去（破壊）された時
-  onBlocksRemoved(callback: (data: any) => void, context?: any) {
+  onBlocksRemoved(callback: (data: ServerBlock) => void, context?: any) {
     gameEvents.on(Event.BLOCKS_REMOVED, callback, context);
   }
 


### PR DESCRIPTION
1. サーバで破壊判定
2. サーバで破壊時間を付与して、キューにつめる。この時点でクライアントにも送信
3. クライアントは受け取ったデータをキューにつめる
4. サーバクライアントともに、同じ時間にブロックを削除する(アイテムのドロップもそのタイミングで同時になる)

以下は latency 200ms  環境のもの

https://user-images.githubusercontent.com/10017674/211815582-1afc995a-2577-487e-9b98-3deb4d44404a.mov

