### PR TITLE
サーバ・クライアントで時刻を同期し、爆発の処理をほぼ同時にした

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,12 +12,15 @@
         "@colyseus/monitor": "^0.14.22",
         "@colyseus/schema": "^1.0.45",
         "colyseus": "^0.14.24",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "matter-js": "^0.18.0",
+        "timesync": "^1.0.11",
         "ts-node": "^10.9.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.15",
         "@types/matter-js": "^0.18.2",
         "@types/node": "^18.11.18",
@@ -184,6 +187,15 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -578,6 +590,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1400,6 +1424,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -1919,6 +1951,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/timesync": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/timesync/-/timesync-1.0.11.tgz",
+      "integrity": "sha512-qT2Y/qAQAeQTa/M+Dteec+76vsUAbY1TQQtXBVTuNMHBkKflT2uLnqG8T+V7eK7CADhwRq+2Etmj5df9VOpkNQ==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2308,6 +2348,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -2639,6 +2688,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -3262,6 +3320,11 @@
         "path-key": "^2.0.0"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
     "object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -3667,6 +3730,14 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "timesync": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/timesync/-/timesync-1.0.11.tgz",
+      "integrity": "sha512-qT2Y/qAQAeQTa/M+Dteec+76vsUAbY1TQQtXBVTuNMHBkKflT2uLnqG8T+V7eK7CADhwRq+2Etmj5df9VOpkNQ==",
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,12 +14,15 @@
     "@colyseus/monitor": "^0.14.22",
     "@colyseus/schema": "^1.0.45",
     "colyseus": "^0.14.24",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "matter-js": "^0.18.0",
+    "timesync": "^1.0.11",
     "ts-node": "^10.9.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.15",
     "@types/matter-js": "^0.18.2",
     "@types/node": "^18.11.18",

--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -30,6 +30,9 @@ export const NOTIFICATION_TYPE = {
   // プレイヤー情報を通知するためのタイプ
   PLAYER_INFO: 2,
 
+  // ゲームの開始に関する情報を通知するためのタイプ
+  GAME_START_INFO: 10,
+
   // 1000 番台はインゲーム内で使用するタイプ
   // プレイヤーの移動を通知するためのタイプ
   PLAYER_MOVE: 1000,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,8 +3,13 @@ import { Server } from 'colyseus';
 import { createServer } from 'http';
 import { monitor } from '@colyseus/monitor';
 import express from 'express';
+import cors from 'cors';
 import GameRoom from './rooms/GameRoom';
 import * as Constants from './constants/constants';
+
+// import する上手いやり方わからず require になってます
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const timesyncServer = require('timesync/server');
 
 const app = express();
 app.use(express.json());
@@ -16,6 +21,10 @@ const gameServer = new Server({
 // TODO: add authentication
 app.use('/monitor', monitor());
 gameServer.define(Constants.GAME_ROOM_KEY, GameRoom);
+
+// 時刻同期用
+app.options('/timesync', cors());
+app.use('/timesync', cors(), timesyncServer.requestHandler);
 
 // TODO: add latency simulation
 // gameServer.simulateLatency(200);

--- a/backend/src/rooms/GameRoom.ts
+++ b/backend/src/rooms/GameRoom.ts
@@ -98,6 +98,12 @@ export default class GameRoom extends Room<GameRoomState> {
     try {
       this.state.gameState.setPlaying();
       this.state.setTimer();
+
+      // ゲームの開始と終了時間を送信
+      this.broadcast(Constants.NOTIFICATION_TYPE.GAME_START_INFO, {
+        startedAt: this.state.timer.startedAt,
+        finishedAt: this.state.timer.finishedAt,
+      });
     } catch (e) {
       console.error(e);
     }

--- a/backend/src/rooms/schema/Timer.ts
+++ b/backend/src/rooms/schema/Timer.ts
@@ -5,11 +5,11 @@ import * as Constants from '../../constants/constants';
 export default class Timer extends Schema {
   // 開始時間
   @type('number')
-  private startedAt!: number;
+  startedAt!: number;
 
   // 終了時間
   @type('number')
-  private finishedAt!: number;
+  finishedAt!: number;
 
   // 残り時間
   @type('number')

--- a/backend/src/types/timesync.d.ts
+++ b/backend/src/types/timesync.d.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 declare module 'timesync' {
-  type TimeSync = {
+  interface TimeSync {
     destroy();
     now(): number;
     on(event: 'change', callback: (offset: number) => void);
@@ -10,9 +11,9 @@ declare module 'timesync' {
 
     send(to: string, data: object, timeout: number): Promise<void>;
     receive(from: string, data: object);
-  };
+  }
 
-  type TimeSyncCreateOptions = {
+  interface TimeSyncCreateOptions {
     interval?: number;
     timeout?: number;
     delay?: number;
@@ -20,7 +21,7 @@ declare module 'timesync' {
     peers?: string | string[];
     server?: string;
     now?: () => number;
-  };
+  }
 
   export function create(options: TimeSyncCreateOptions): TimeSync;
 

--- a/backend/src/types/timesync.d.ts
+++ b/backend/src/types/timesync.d.ts
@@ -1,0 +1,38 @@
+declare module 'timesync' {
+  type TimeSync = {
+    destroy();
+    now(): number;
+    on(event: 'change', callback: (offset: number) => void);
+    on(event: 'error', callback: (err: any) => void);
+    on(event: 'sync', callback: (value: 'start' | 'end') => void);
+    off(event: 'change' | 'error' | 'sync', callback?: () => void);
+    sync();
+
+    send(to: string, data: object, timeout: number): Promise<void>;
+    receive(from: string, data: object);
+  };
+
+  type TimeSyncCreateOptions = {
+    interval?: number;
+    timeout?: number;
+    delay?: number;
+    repeat?: number;
+    peers?: string | string[];
+    server?: string;
+    now?: () => number;
+  };
+
+  export function create(options: TimeSyncCreateOptions): TimeSync;
+
+  export = TimeSync;
+}
+
+declare module 'timesync/server' {
+  import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+  import type { createServer as createHttpServer, Server } from 'http';
+  function requestHandler(req: Request | ExpressRequest, res: Response | ExpressResponse): void;
+
+  function createServer(): ReturnType<typeof createHttpServer>;
+
+  function attachServer(server: Server, path?: string): void;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["node_modules/types", "src/@types"]
   },
   "include": ["**/*"]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.5.0",
-        "recoil": "^0.7.6"
+        "recoil": "^0.7.6",
+        "timesync": "^1.0.11"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -881,7 +882,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1320,8 +1320,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoevents": {
       "version": "5.1.13",
@@ -1939,6 +1938,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/timesync": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/timesync/-/timesync-1.0.11.tgz",
+      "integrity": "sha512-qT2Y/qAQAeQTa/M+Dteec+76vsUAbY1TQQtXBVTuNMHBkKflT2uLnqG8T+V7eK7CADhwRq+2Etmj5df9VOpkNQ==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -2739,7 +2746,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -3060,8 +3066,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoevents": {
       "version": "5.1.13",
@@ -3467,6 +3472,14 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
+      }
+    },
+    "timesync": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/timesync/-/timesync-1.0.11.tgz",
+      "integrity": "sha512-qT2Y/qAQAeQTa/M+Dteec+76vsUAbY1TQQtXBVTuNMHBkKflT2uLnqG8T+V7eK7CADhwRq+2Etmj5df9VOpkNQ==",
+      "requires": {
+        "debug": "^4.3.4"
       }
     },
     "to-fast-properties": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.5.0",
-    "recoil": "^0.7.6"
+    "recoil": "^0.7.6",
+    "timesync": "^1.0.11"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/frontend/src/events/GameEvents.ts
+++ b/frontend/src/events/GameEvents.ts
@@ -5,6 +5,7 @@ export enum Event {
   PLAYER_JOINED_ROOM = 'player-joined-room',
   PLAYER_LEFT_ROOM = 'player-left-room',
   TIMER_UPDATED = 'timer-updated',
+  GAME_START_INFO_RECEIVED = 'game-start-info-received',
   GAME_STATE_UPDATED = 'game-state-updated',
   BOMB_ADDED = 'bomb-added',
   BOMB_REMOVED = 'bomb-removed',

--- a/frontend/src/items/Bomb.ts
+++ b/frontend/src/items/Bomb.ts
@@ -216,20 +216,18 @@ export default class Bomb extends Phaser.Physics.Matter.Sprite {
 
   // 誘爆時の処理
   detonated(id: string) {
-    this.scene.time.addEvent({
-      delay: Constants.BOMB_DETONATION_DELAY,
-      callback: () => {
-        this.explode();
-        this.afterExplosion();
-      },
-    });
+    // addEvent より setTimeout の方が遅延がマシだったので setTimeout を使う
+    setTimeout(() => {
+      this.explode();
+      this.afterExplosion();
+    }, Constants.BOMB_DETONATION_DELAY);
   }
 
   // 爆発するまでの時間を返す
   getRemainTime(): number {
     if (this.removedAt === null || this.removedAt === 0) return 0;
-    const game = getGameScene();
-    return this.removedAt - game.getServerTime() <= 0 ? 0 : this.removedAt - game.getServerTime();
+    const now: number = getGameScene().getNetwork().now();
+    return this.removedAt - now <= 0 ? 0 : this.removedAt - now;
   }
 
   public getIsExploded(): boolean {
@@ -276,7 +274,7 @@ Phaser.GameObjects.GameObjectFactory.register(
         }
         clearInterval(timer);
       }
-    }, 100);
+    }, 10); // サーバとの遅延を減らすため、10msごとに確認
 
     return sprite;
   }

--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -24,7 +24,6 @@ import Bomb from '../items/Bomb';
 import Item from '../items/Item';
 import initializeKeys from '../utils/key';
 import Network from '../services/Network';
-import GameHeader from './GameHeader';
 import OtherPlayer from '../characters/OtherPlayer';
 import { Block } from '../items/Block';
 import phaserJuice from '../lib/phaserJuice';
@@ -122,7 +121,6 @@ export default class Game extends Phaser.Scene {
 
   private initNetworkEvents() {
     this.network.onPlayerJoinedRoom(this.handlePlayerJoinedRoom, this); // 他のプレイヤーの参加イベント
-    this.network.onTimerUpdated(this.handleTimerUpdated, this); // タイマーの変更イベント
     this.network.onGameStateUpdated(this.handleGameStateChanged, this); // gameStateの変更イベント
     // TODO: アイテムをとって火力が上がった場合の処理を追加する
     this.network.onBombAdded(this.handleBombAdded, this); // プレイヤーのボム追加イベント
@@ -171,14 +169,6 @@ export default class Game extends Phaser.Scene {
     const otherPlayer = this.otherPlayers.get(sessionId);
     otherPlayer?.destroy();
     this.otherPlayers.delete(sessionId);
-  }
-
-  private handleTimerUpdated(data: any) {
-    const header = this.scene.get(Config.SCENE_NAME_GAME_HEADER) as GameHeader;
-    data.forEach((v: any) => {
-      if (v.field === 'now') this.setServerTime(v.value);
-      if (v.field === 'remainTime') header.updateTextTimer(v.value);
-    });
   }
 
   private async handleGameStateChanged(data: any) {

--- a/frontend/src/scenes/GameHeader.ts
+++ b/frontend/src/scenes/GameHeader.ts
@@ -7,6 +7,7 @@ import ToString from '../utils/color';
 import { getGameScene } from '../utils/globalGame';
 import { isMute, toggle } from '../utils/sound';
 import convertSecondsToMMSS from '../utils/timer';
+import Network from '../services/Network';
 
 export default class GameHeader extends Phaser.Scene {
   private readonly width: number;
@@ -19,6 +20,7 @@ export default class GameHeader extends Phaser.Scene {
   private textBombStrength!: Phaser.GameObjects.Text;
   private textSpeed!: Phaser.GameObjects.Text;
   private iconVolume!: Phaser.GameObjects.Image;
+  private network!: Network;
 
   constructor() {
     super(Config.SCENE_NAME_GAME_HEADER);
@@ -59,7 +61,13 @@ export default class GameHeader extends Phaser.Scene {
       .on('pointerdown', () => this.updateVolumeIcon());
   }
 
+  create(data: { network: Network }) {
+    if (data.network == null) return;
+    this.network = data.network;
+  }
+
   update() {
+    this.updateTextTimer(this.network.getGameFinishedAt() - this.network.now());
     this.textBombCount.setText(`×${this.player.getItemCountOfBombCount()}`);
     this.textBombStrength.setText(`×${this.player.getItemCountOfBombStrength()}`);
     this.textSpeed.setText(`×${this.player.getItemCountOfSpeed()}`);

--- a/frontend/src/scenes/Preloader.ts
+++ b/frontend/src/scenes/Preloader.ts
@@ -102,6 +102,8 @@ export default class Preloader extends Phaser.Scene {
     this.scene.start(Config.SCENE_NAME_GAME, {
       network: this.network,
     });
-    this.scene.start(Config.SCENE_NAME_GAME_HEADER);
+    this.scene.start(Config.SCENE_NAME_GAME_HEADER, {
+      network: this.network,
+    });
   }
 }

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -39,6 +39,7 @@ export default class Network {
       server: `${endpoint}/timesync`,
       interval: 1000,
     });
+    this.ts.sync();
   }
 
   now(): number {

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -8,9 +8,11 @@ import ServerBlast from '../../../backend/src/rooms/schema/Blast';
 import { Bomb as ServerBomb } from '../../../backend/src/rooms/schema/Bomb';
 import { gameEvents, Event } from '../events/GameEvents';
 import MyPlayer from '../characters/MyPlayer';
+import TimeSync, { create as TimeCreate } from 'timesync';
 
 export default class Network {
   private readonly client: Client;
+  private ts!: TimeSync;
   public room?: Room<GameRoomState>;
 
   allRooms: RoomAvailable[] = [];
@@ -19,22 +21,41 @@ export default class Network {
   constructor() {
     const protocol = window.location.protocol.replace('http', 'ws');
 
+    let endpoint = '';
     if (import.meta.env.PROD) {
-      const endpoint = Config.serverUrl;
+      endpoint = Config.serverUrl;
       this.client = new Client(endpoint);
     } else {
-      const endpoint = `${protocol}//${window.location.hostname}:${Constants.SERVER_LISTEN_PORT}`;
+      endpoint = `${protocol}//${window.location.hostname}:${Constants.SERVER_LISTEN_PORT}`;
       this.client = new Client(endpoint);
     }
+    this.syncClock(endpoint);
     this.joinOrCreateRoom().catch((err) => console.log(err));
+  }
+
+  syncClock(endpoint: string) {
+    endpoint = endpoint.replace('ws', 'http');
+    this.ts = TimeCreate({
+      server: `${endpoint}/timesync`,
+      interval: 1000,
+    });
+  }
+
+  now(): number {
+    return this.ts.now();
   }
 
   async joinOrCreateRoom() {
     this.room = await this.client.joinOrCreate(Constants.GAME_ROOM_KEY);
+
     // ゲーム開始の通知
     // FIXME: ここでやるのではなくロビーでホストがスタートボタンを押した時にやる
-    this.sendGameProgress();
     this.initialize();
+
+    // ゲーム開始情報の受信イベント
+    // FIXME: ここでやるのではなくロビーでホストがスタートボタンを押した時にやる
+    this.receiveGameStartInfo(this.handleGameStartInfoReceived, this);
+    this.sendGameProgress(Constants.GAME_STATE.PLAYING);
   }
 
   initialize() {
@@ -70,10 +91,6 @@ export default class Network {
       gameEvents.emit(Event.BLAST_REMOVED, data);
     };
 
-    this.room.state.timer.onChange = (data: any) => {
-      gameEvents.emit(Event.TIMER_UPDATED, data);
-    };
-
     this.room.state.gameState.onChange = (data: any) => {
       gameEvents.emit(Event.GAME_STATE_UPDATED, data);
     };
@@ -89,6 +106,10 @@ export default class Network {
     this.room.state.items.onRemove = (data: any) => {
       gameEvents.emit(Event.ITEM_REMOVED, data);
     };
+
+    this.room.onMessage(Constants.NOTIFICATION_TYPE.GAME_START_INFO, (data) => {
+      gameEvents.emit(Event.GAME_START_INFO_RECEIVED, data);
+    });
   }
 
   // 自分がルームに参加した時
@@ -125,11 +146,6 @@ export default class Network {
     gameEvents.on(Event.BLAST_REMOVED, callback, context);
   }
 
-  // タイマーが更新された時
-  onTimerUpdated(callback: (data: any) => void, context?: any) {
-    gameEvents.on(Event.TIMER_UPDATED, callback, context);
-  }
-
   // gameState が更新された時
   onGameStateUpdated(callback: (data: any) => Promise<void>, context?: any) {
     gameEvents.on(Event.GAME_STATE_UPDATED, callback, context);
@@ -149,6 +165,11 @@ export default class Network {
     gameEvents.on(Event.ITEM_REMOVED, callback, context);
   }
 
+  // ゲーム開始に関する情報を受け取った時
+  receiveGameStartInfo(callback: (data: any) => void, context?: any) {
+    gameEvents.on(Event.GAME_START_INFO_RECEIVED, callback, context);
+  }
+
   // 自分のプレイヤー動作を送る
   sendPlayerMove(player: MyPlayer, isInput: boolean) {
     this.room?.send(Constants.NOTIFICATION_TYPE.PLAYER_MOVE, { player, isInput });
@@ -160,7 +181,26 @@ export default class Network {
   }
 
   // 自分のゲーム状態を送る
-  sendGameProgress() {
-    this.room?.send(Constants.NOTIFICATION_TYPE.GAME_PROGRESS);
+  sendGameProgress(state: Constants.GAME_STATE_TYPE) {
+    this.room?.send(Constants.NOTIFICATION_TYPE.GAME_PROGRESS, state);
+  }
+
+  // FIXME:
+  // 本来はここにおくべきではなく、ロビー画面でゲーム開始ボタンを押した時にやればいいのだが
+  // まだロビーがないのでここにおく
+  private gameStartedAt!: number; // ゲームの開始時間
+  private gameFinishedAt!: number; // ゲームの終了時間
+
+  private handleGameStartInfoReceived(data: any) {
+    this.gameStartedAt = data.startedAt;
+    this.gameFinishedAt = data.finishedAt;
+  }
+
+  public getGameStartedAt(): number {
+    return this.gameStartedAt;
+  }
+
+  public getGameFinishedAt(): number {
+    return this.gameFinishedAt;
   }
 }

--- a/frontend/src/types/timesync.d.ts
+++ b/frontend/src/types/timesync.d.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 declare module 'timesync' {
-  type TimeSync = {
+  interface TimeSync {
     destroy();
     now(): number;
     on(event: 'change', callback: (offset: number) => void);
@@ -10,9 +11,9 @@ declare module 'timesync' {
 
     send(to: string, data: object, timeout: number): Promise<void>;
     receive(from: string, data: object);
-  };
+  }
 
-  type TimeSyncCreateOptions = {
+  interface TimeSyncCreateOptions {
     interval?: number;
     timeout?: number;
     delay?: number;
@@ -20,7 +21,7 @@ declare module 'timesync' {
     peers?: string | string[];
     server?: string;
     now?: () => number;
-  };
+  }
 
   export function create(options: TimeSyncCreateOptions): TimeSync;
 

--- a/frontend/src/types/timesync.d.ts
+++ b/frontend/src/types/timesync.d.ts
@@ -1,0 +1,38 @@
+declare module 'timesync' {
+  type TimeSync = {
+    destroy();
+    now(): number;
+    on(event: 'change', callback: (offset: number) => void);
+    on(event: 'error', callback: (err: any) => void);
+    on(event: 'sync', callback: (value: 'start' | 'end') => void);
+    off(event: 'change' | 'error' | 'sync', callback?: () => void);
+    sync();
+
+    send(to: string, data: object, timeout: number): Promise<void>;
+    receive(from: string, data: object);
+  };
+
+  type TimeSyncCreateOptions = {
+    interval?: number;
+    timeout?: number;
+    delay?: number;
+    repeat?: number;
+    peers?: string | string[];
+    server?: string;
+    now?: () => number;
+  };
+
+  export function create(options: TimeSyncCreateOptions): TimeSync;
+
+  export = TimeSync;
+}
+
+declare module 'timesync/server' {
+  import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+  import type { createServer as createHttpServer, Server } from 'http';
+  function requestHandler(req: Request | ExpressRequest, res: Response | ExpressResponse): void;
+
+  function createServer(): ReturnType<typeof createHttpServer>;
+
+  function attachServer(server: Server, path?: string): void;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
- fixed #202
- fixed #179

大体、ローカルだと20ms 前後にした

# やったこと

timesync  というライブラリを入れて、クライアントとサーバの時間を同期した。

この時間をクライアントで利用することでサーバと同じ時刻が使えるようになったので、
この時間を用いて爆発の判定などを行う。

# 悩み

- timeSync  が commonJS かつ、types がないので綺麗な入れ方がわかんなかった
- ローカルでやったら誘爆の処理がフロントの方が15ms ぐらい早くなるという問題が・・