### PR TITLE
プレイヤーの移動を全てサーバで行うようにした

### DIFF
--- a/backend/src/game_engine/services/bombService.ts
+++ b/backend/src/game_engine/services/bombService.ts
@@ -90,4 +90,38 @@ export default class BombService {
     });
     return isExists;
   }
+
+  // 現在のボムのリストを返す
+  private listBombs(): Matter.Body[] {
+    return Array.from(this.gameEngine.bombBodies.values());
+  }
+
+  // 爆弾の衝突判定を更新する
+  updateBombCollision() {
+    this.setSensorFalseIfNoBodyOverlapped();
+  }
+
+  // 全ての爆弾に対して、爆弾に他のオブジェクトが重なっていない場合は衝突判定を有効にする
+  private setSensorFalseIfNoBodyOverlapped() {
+    this.listBombs().forEach((bombBody) => {
+      // すでに当たり判定があるなら何もしない
+      if (!bombBody.isSensor) return;
+
+      const bombId = this.gameEngine.bombIdByBodyId.get(bombBody.id);
+      if (bombId === undefined) return;
+      const bomb = this.gameEngine.state.bombs.get(bombId);
+      if (bomb === undefined) return;
+
+      // ボムが爆発している場合は処理を終了する
+      if (bomb.isExploded()) return;
+
+      // ボムに重なっているオブジェクトの取得
+      const bodies = Matter.Query.point(this.gameEngine.world.bodies, {
+        x: bombBody.position.x,
+        y: bombBody.position.y,
+      });
+
+      if (bodies.length <= 1) Matter.Body.set(bombBody, 'isSensor', false);
+    });
+  }
 }

--- a/backend/src/game_engine/services/mapService.ts
+++ b/backend/src/game_engine/services/mapService.ts
@@ -76,8 +76,8 @@ export default class MapService {
     return Matter.Bodies.rectangle(
       tileWidth / 2 + tileWidth * x,
       Constants.HEADER_HEIGHT + tileHeight / 2 + tileHeight * y,
-      tileWidth * 0.9,
-      tileHeight * 0.9,
+      tileWidth,
+      tileHeight,
       {
         chamfer: {
           radius,
@@ -98,8 +98,8 @@ export default class MapService {
     const blockBody = Matter.Bodies.rectangle(
       tileWidth / 2 + tileWidth * x,
       Constants.HEADER_HEIGHT + tileHeight / 2 + tileHeight * y,
-      tileWidth * 0.9,
-      tileHeight * 0.9,
+      tileWidth,
+      tileHeight,
       {
         isStatic: true,
         label: Constants.OBJECT_LABEL.BLOCK,

--- a/backend/src/game_engine/services/playerService.ts
+++ b/backend/src/game_engine/services/playerService.ts
@@ -57,33 +57,23 @@ export default class PlayerService {
     if (playerBody === undefined || playerState === undefined) return;
 
     let data: any;
-    const velocity = player.speed;
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     while ((data = player.inputQueue.shift())) {
-      const { player: playerData, isInput } = data;
+      const { player: playerData, inputPayload, isInput } = data;
 
       if (isInput === false) {
         Matter.Body.setVelocity(playerBody, { x: 0, y: 0 });
-
-        // velocity を 0 にするだけだとちょっとずれるので、位置を補正する
-        // この時、ローカルとサーバーの位置が大きい場合は、サーバーの位置に補正する
-        if (
-          Math.abs(playerData.x - player.x) > Constants.PLAYER_TOLERANCE_DISTANCE ||
-          Math.abs(playerData.y - player.y) > Constants.PLAYER_TOLERANCE_DISTANCE
-        ) {
-          Matter.Body.setPosition(playerBody, { x: player.x, y: player.y });
-        } else {
-          Matter.Body.setPosition(playerBody, { x: playerData.x, y: playerData.y });
-        }
+        Matter.Body.setPosition(playerBody, { x: player.x, y: player.y });
       } else {
-        let newVx = playerData.x - player.x;
-        let newVy = playerData.y - player.y;
-
-        if (Math.abs(newVx) > velocity) newVx = velocity * Math.sign(newVx);
-        if (Math.abs(newVy) > velocity) newVy = velocity * Math.sign(newVy);
-
-        Matter.Body.setVelocity(playerBody, { x: newVx, y: newVy });
+        const velocity = player.speed;
+        let vx = 0;
+        let vy = 0;
+        if (inputPayload.left === true) vx -= velocity;
+        if (inputPayload.right === true) vx += velocity;
+        if (inputPayload.up === true) vy -= velocity;
+        if (inputPayload.down === true) vy += velocity;
+        Matter.Body.setVelocity(playerBody, { x: vx, y: vy });
       }
 
       playerState.frameKey = playerData.frameKey;

--- a/backend/src/rooms/GameRoom.ts
+++ b/backend/src/rooms/GameRoom.ts
@@ -75,6 +75,9 @@ export default class GameRoom extends Room<GameRoomState> {
           this.engine.playerService.updatePlayer(player);
         }
 
+        // 爆弾の衝突判定の更新（プレイヤーが降りた場合は判定を変える)
+        this.engine.bombService.updateBombCollision();
+
         // 爆弾の処理
         this.objectCreateHandler(this.state.getBombToCreateQueue(), (bomb) =>
           this.createBombEvent(bomb)

--- a/frontend/src/characters/MyPlayer.ts
+++ b/frontend/src/characters/MyPlayer.ts
@@ -12,7 +12,6 @@ export default class MyPlayer extends Player {
   private serverX: number;
   private serverY: number;
   private frameKey: number;
-  private readonly remoteRef: Phaser.GameObjects.Rectangle;
   // frame をサーバに送信するための不可視のプレイヤー
   private readonly dummyPlayer: Player;
   private readonly dead_se;
@@ -38,8 +37,6 @@ export default class MyPlayer extends Player {
     this.serverX = x;
     this.serverY = y;
     this.frameKey = 14;
-    // TODO: 不要
-    this.remoteRef = this.scene.add.rectangle(this.x, this.y, this.width, this.height, 0xfff, 0.3);
     this.dummyPlayer = this.scene.add.player(sessionId, this.x, this.y, 'player', 14);
     this.dummyPlayer.setVisible(false).setSensor(true);
     this.dead_se = this.scene.sound.add('gameOver', {
@@ -57,7 +54,6 @@ export default class MyPlayer extends Player {
     this.serverY = player.y;
     this.frameKey = player.frameKey;
 
-    this.updateRemoteRef(player);
     this.forceMovePlayerPosition(player);
     this.setHP(player.hp);
     if (this.isDead()) {
@@ -72,12 +68,6 @@ export default class MyPlayer extends Player {
     this.setSpeed(player.speed);
     this.setBombStrength(player.bombStrength);
     this.setMaxBombCount(player.maxBombCount);
-  }
-
-  // サーバのプレイヤーの位置を反映させる
-  private updateRemoteRef(player: ServerPlayer) {
-    if (this.isDead()) return;
-    this.remoteRef.setPosition(player.x, player.y);
   }
 
   update(cursorKeys: NavKeys, network: Network) {

--- a/frontend/src/characters/MyPlayer.ts
+++ b/frontend/src/characters/MyPlayer.ts
@@ -9,7 +9,12 @@ import { getGameScene } from '../utils/globalGame';
 import Player from './Player';
 
 export default class MyPlayer extends Player {
+  private serverX: number;
+  private serverY: number;
+  private frameKey: number;
   private readonly remoteRef: Phaser.GameObjects.Rectangle;
+  // frame をサーバに送信するための不可視のプレイヤー
+  private readonly dummyPlayer: Player;
   private readonly dead_se;
   private readonly item_get_se;
 
@@ -30,7 +35,13 @@ export default class MyPlayer extends Player {
     options?: Phaser.Types.Physics.Matter.MatterBodyConfig
   ) {
     super(sessionId, world, x, y, texture, frame, options);
+    this.serverX = x;
+    this.serverY = y;
+    this.frameKey = 14;
+    // TODO: 不要
     this.remoteRef = this.scene.add.rectangle(this.x, this.y, this.width, this.height, 0xfff, 0.3);
+    this.dummyPlayer = this.scene.add.player(sessionId, this.x, this.y, 'player', 14);
+    this.dummyPlayer.setVisible(false).setSensor(true);
     this.dead_se = this.scene.sound.add('gameOver', {
       volume: Config.SOUND_VOLUME * 1.5,
     });
@@ -42,6 +53,9 @@ export default class MyPlayer extends Player {
   // player.onChange のコールバック
   handleServerChange(player: ServerPlayer) {
     if (this.isDead()) return;
+    this.serverX = player.x;
+    this.serverY = player.y;
+    this.frameKey = player.frameKey;
 
     this.updateRemoteRef(player);
     this.forceMovePlayerPosition(player);
@@ -69,7 +83,11 @@ export default class MyPlayer extends Player {
   update(cursorKeys: NavKeys, network: Network) {
     if (this.isDead()) return false;
 
-    // send input to the server
+    // サーバの位置に合わせて移動
+    this.setVelocity(this.serverX - this.x, this.serverY - this.y);
+    this.setFrame(this.frameKey);
+
+    // キーボードの入力をサーバに送信
     this.inputPayload.left = cursorKeys.left.isDown || cursorKeys.A.isDown;
     this.inputPayload.right = cursorKeys.right.isDown || cursorKeys.D.isDown;
     this.inputPayload.up = cursorKeys.up.isDown || cursorKeys.W.isDown;
@@ -82,32 +100,28 @@ export default class MyPlayer extends Player {
         this.inputPayload.down) &&
       !document.hidden;
 
+    // アニメーションの結果はフロントで管理するため、dummy Player を先に移動させて frame を送る。
     let vx = 0; // velocity x
     let vy = 0; // velocity y
 
     if (isInput) {
       const velocity = this.getSpeed();
-      if (this.inputPayload.left) {
-        vx -= velocity;
-      } else if (this.inputPayload.right) {
-        vx += velocity;
-      }
-
-      if (this.inputPayload.up) {
-        vy -= velocity;
-      } else if (this.inputPayload.down) {
-        vy += velocity;
-      }
+      if (this.inputPayload.left) vx -= velocity;
+      if (this.inputPayload.right) vx += velocity;
+      if (this.inputPayload.up) vy -= velocity;
+      if (this.inputPayload.down) vy += velocity;
     }
 
-    this.setVelocity(vx, vy);
-    network.sendPlayerMove(this, isInput);
+    if (vx > 0) this.dummyPlayer.play('player_right', true);
+    else if (vx < 0) this.dummyPlayer.play('player_left', true);
+    else if (vy > 0) this.dummyPlayer.play('player_down', true);
+    else if (vy < 0) this.dummyPlayer.play('player_up', true);
+    else this.dummyPlayer.stop();
 
-    if (vx > 0) this.play('player_right', true);
-    else if (vx < 0) this.play('player_left', true);
-    else if (vy > 0) this.play('player_down', true);
-    else if (vy < 0) this.play('player_up', true);
-    else this.stop();
+    // 自分自身の移動はサーバに管理してもらう都合上送れないが
+    // アニメーションはフロントで管理するため、dummy Player を先に移動させて frame を送る。
+    // this.dummyPlayer.setVelocity(vx, vy);
+    network.sendPlayerMove(this.dummyPlayer, this.inputPayload, isInput);
 
     // bomb 設置
     const isSpaceJustDown = Phaser.Input.Keyboard.JustDown(cursorKeys.space);

--- a/frontend/src/characters/Player.ts
+++ b/frontend/src/characters/Player.ts
@@ -206,3 +206,24 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     this.scene.cameras.main.shake(duration, 0.01);
   }
 }
+
+Phaser.GameObjects.GameObjectFactory.register(
+  'player',
+  function (
+    this: Phaser.GameObjects.GameObjectFactory,
+    sessionId: string,
+    x: number,
+    y: number,
+    texture: string,
+    frame?: string | number,
+    options?: Phaser.Types.Physics.Matter.MatterBodyConfig
+  ) {
+    const sprite = new Player(sessionId, this.scene.matter.world, x, y, texture, frame, options);
+
+    // 使う用途がダミーなので、ここではコメントアウト
+    // this.displayList.add(sprite);
+    this.updateList.add(sprite);
+
+    return sprite;
+  }
+);

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -8,6 +8,7 @@ import ServerBlast from '../../../backend/src/rooms/schema/Blast';
 import { Bomb as ServerBomb } from '../../../backend/src/rooms/schema/Bomb';
 import { gameEvents, Event } from '../events/GameEvents';
 import MyPlayer from '../characters/MyPlayer';
+import Player from '../characters/Player';
 
 export default class Network {
   private readonly client: Client;
@@ -150,8 +151,8 @@ export default class Network {
   }
 
   // 自分のプレイヤー動作を送る
-  sendPlayerMove(player: MyPlayer, isInput: boolean) {
-    this.room?.send(Constants.NOTIFICATION_TYPE.PLAYER_MOVE, { player, isInput });
+  sendPlayerMove(player: Player, inputPayload: any, isInput: boolean) {
+    this.room?.send(Constants.NOTIFICATION_TYPE.PLAYER_MOVE, { player, inputPayload, isInput });
   }
 
   // 自分の爆弾を送る

--- a/frontend/src/types/GameObjectFactory.d.ts
+++ b/frontend/src/types/GameObjectFactory.d.ts
@@ -1,3 +1,4 @@
+import Player from '../characters/Player';
 import MyPlayer from '../characters/MyPlayer';
 import OtherPlayer from '../characters/OtherPlayer';
 import { Block } from '../items/Block';
@@ -11,6 +12,14 @@ export {};
 declare global {
   namespace Phaser.GameObjects {
     interface GameObjectFactory {
+      player: (
+        sessionId: string,
+        x: number,
+        y: number,
+        texture: string,
+        frame?: string | number,
+        options?: Phaser.Types.Physics.Matter.MatterBodyConfig
+      ) => Player;
       myPlayer: (
         sessionId: string,
         x: number,


### PR DESCRIPTION
- closed #178 
- closed #174

frameKey の送信を行いたかったのですが、frameKey はクライアント上でアニメーションが始まらないとそもそも送れないのでダミーユーザを不可視で追加し frameKey を取得できるようにしています。

**左が操作しているキャラの動きなんですが、なんか動きに違和感あるんだよなあ・・・**

https://user-images.githubusercontent.com/10017674/212146443-c4a9f9e5-bdf1-41b8-afe4-b07c18d9031d.mov

