### PR TITLE
タブを開き直すと何度もブロックが落ちてくるイベントが発生するバグ修正

### DIFF
--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -120,7 +120,7 @@ export default class Game extends Phaser.Scene {
 
   private timeEventHandler() {
     // 壁落下イベント
-    if (this.network.remainTime() <= Constants.INGAME_EVENT_DROP_WALLS_TIME) {
+    if (this.network.remainTime() === Constants.INGAME_EVENT_DROP_WALLS_TIME) {
       if (!this.IsFinishedDropWallsEvent) dropWalls();
       this.IsFinishedDropWallsEvent = true;
     }


### PR DESCRIPTION
残り30秒未満でタブ開き直すと何度もブロックが落ちてくるイベントが発生するバグ修正