### PR TITLE
room schema を追加して、クライアントからの部屋情報を管理するようにした

### DIFF
--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -133,6 +133,9 @@ export const DEFAULT_TIP_SIZE = 64; // デフォルトのチップサイズ
 // マップの設定
 export const DEFAULT_TILE_ROWS = 13; // タイルの行数
 export const DEFAULT_TILE_COLS = 15; // タイルの列数
+export const LIMIT_TILE_ROWS = 13; // タイルの行数
+export const LIMIT_TILE_COLS = 15; // タイルの列数
+
 export const TILE_WIDTH = DEFAULT_TIP_SIZE; // タイルの横幅
 export const TILE_HEIGHT = DEFAULT_TIP_SIZE; // タイルの縦幅
 export const MAX_BLOCKS = 100;
@@ -166,6 +169,23 @@ export const PLAYER_HEIGHT = DEFAULT_TIP_SIZE; // プレイヤーの縦幅
 
 // character スプライト key
 export const CHARACTERS = ['cat', 'wolf', 'bunny', 'pig'];
+
+/*
+ルームの定義
+*/
+
+// ブロックの配置率
+export const ROOM_INFO_BLOCK_PLACEMENT_RATE = {
+  0: 0,
+  50: 0.5,
+  75: 0.75,
+  100: 1,
+};
+
+export const ROOM_INFO_DEFAULT_BLOCK_PLACEMENT_RATE = ROOM_INFO_BLOCK_PLACEMENT_RATE[75];
+
+export type ROOM_INFO_BLOCK_PLACEMENT_RATES =
+  typeof ROOM_INFO_BLOCK_PLACEMENT_RATE[keyof typeof ROOM_INFO_BLOCK_PLACEMENT_RATE];
 
 /*
 敵の定義
@@ -255,6 +275,9 @@ export const INITIAL_PLAYER_HP = 1;
 // プレイヤーの最大HP
 export const MAX_PLAYER_HP = 3;
 
+// このゲームで設定できるプレイヤーの最大HP
+export const LIMIT_PLAYER_HP = 10;
+
 // 初期に設置できる爆弾の数
 export const INITIAL_SETTABLE_BOMB_COUNT = 1;
 
@@ -312,7 +335,22 @@ export const PLAYER_TOLERANCE_DISTANCE = 100;
 
 // ゲームの制限時間
 export const GAME_PREPARING_TIME = 5; // ゲーム開始演出の時間
-export const TIME_LIMIT_SEC = 121 + GAME_PREPARING_TIME; // (+1秒するといい感じに表示される)
+export const TIME_LIMIT_SEC = 120 + 1 + GAME_PREPARING_TIME; // (+1秒するといい感じに表示される)
+
+// ルームの制限時間の定義
+export const ROOM_INFO_TIME_LIMIT_SEC = {
+  1: 60 + 1 + GAME_PREPARING_TIME,
+  2: 120 + 1 + GAME_PREPARING_TIME,
+  3: 180 + 1 + GAME_PREPARING_TIME,
+  4: 240 + 1 + GAME_PREPARING_TIME,
+  5: 300 + 1 + GAME_PREPARING_TIME,
+};
+
+export type ROOM_INFO_TIME_LIMIT_SEC_TYPES =
+  typeof ROOM_INFO_TIME_LIMIT_SEC[keyof typeof ROOM_INFO_TIME_LIMIT_SEC];
+
+// デフォルトのルームの制限時間
+export const ROOM_INFO_DEFAULT_TIME_LIMIT_SEC = ROOM_INFO_TIME_LIMIT_SEC[2];
 
 /*
 アイテムの定義
@@ -356,6 +394,9 @@ export const ITEM_PLACE_COUNT = {
   [ITEM_TYPE.PENETRATION_BOMB]: 0,
   [ITEM_TYPE.PLAYER_SPEED]: 8,
 };
+
+// 各アイテムを配置する最大数
+export const ITEM_PLACE_MAX_COUNT_PER_ITEM = 99;
 
 /*
 衝突判定のカテゴリ

--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -336,21 +336,11 @@ export const PLAYER_TOLERANCE_DISTANCE = 100;
 // ゲームの制限時間
 export const GAME_PREPARING_TIME = 5; // ゲーム開始演出の時間
 
-// ルームの制限時間の定義
-export const ROOM_INFO_TIME_LIMIT_SEC = {
-  // +1秒するといい感じに表示される
-  1: 60 + 1 + GAME_PREPARING_TIME,
-  2: 120 + 1 + GAME_PREPARING_TIME,
-  3: 180 + 1 + GAME_PREPARING_TIME,
-  4: 240 + 1 + GAME_PREPARING_TIME,
-  5: 300 + 1 + GAME_PREPARING_TIME,
-};
-
-export type ROOM_INFO_TIME_LIMIT_SEC_TYPES =
-  typeof ROOM_INFO_TIME_LIMIT_SEC[keyof typeof ROOM_INFO_TIME_LIMIT_SEC];
-
 // デフォルトのルームの制限時間
-export const ROOM_INFO_DEFAULT_TIME_LIMIT_SEC = ROOM_INFO_TIME_LIMIT_SEC[2];
+export const DEFAULT_TIME_LIMIT_SEC = 120; // 2分
+
+// 最大のルームの制限時間
+export const MAX_TIME_LIMIT_SEC = 300; // 5分
 
 /*
 アイテムの定義

--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -335,10 +335,10 @@ export const PLAYER_TOLERANCE_DISTANCE = 100;
 
 // ゲームの制限時間
 export const GAME_PREPARING_TIME = 5; // ゲーム開始演出の時間
-export const TIME_LIMIT_SEC = 120 + 1 + GAME_PREPARING_TIME; // (+1秒するといい感じに表示される)
 
 // ルームの制限時間の定義
 export const ROOM_INFO_TIME_LIMIT_SEC = {
+  // +1秒するといい感じに表示される
   1: 60 + 1 + GAME_PREPARING_TIME,
   2: 120 + 1 + GAME_PREPARING_TIME,
   3: 180 + 1 + GAME_PREPARING_TIME,

--- a/backend/src/game_engine/services/enemyService.ts
+++ b/backend/src/game_engine/services/enemyService.ts
@@ -186,7 +186,7 @@ export default class EnemyService {
         )
       );
 
-      const gameStep = enemy.getStep(state.timer, state.room.timeLimit);
+      const gameStep = enemy.getStep(state.timer, state.room.timeLimitSec);
 
       // 爆弾をおいたときに、一度に破壊できるブロックが多い場所を評価するマップを作成する
       let goodBombPlaceMap: number[][] = [];
@@ -328,7 +328,7 @@ export default class EnemyService {
           highPriorityForBlastRadiusMap,
           enemy,
           state.timer,
-          state.room.timeLimit
+          state.room.timeLimitSec
         );
       }
     }

--- a/backend/src/rooms/GameRoom.ts
+++ b/backend/src/rooms/GameRoom.ts
@@ -49,7 +49,6 @@ export default class GameRoom extends Room<GameRoomState> {
         this.state.players.forEach((player) => (isLobbyReady = isLobbyReady && player.isReady()));
         if (isLobbyReady) {
           // room に設定を反映
-          gameSettings.numberOfPlayers = this.state.players.size;
           this.state.initializeRoom(gameSettings);
           this.state.initializePlayers();
 

--- a/backend/src/rooms/GameRoom.ts
+++ b/backend/src/rooms/GameRoom.ts
@@ -51,6 +51,7 @@ export default class GameRoom extends Room<GameRoomState> {
           // room に設定を反映
           gameSettings.numberOfPlayers = this.state.players.size;
           this.state.initializeRoom(gameSettings);
+          this.state.initializePlayers();
 
           // 全クライアントの準備が完了している場合 Matter エンジンにマップ・プレイヤーを追加してゲームデータを送ž
           this.engine.mapService.addMapToWorld(this.state.room.mapRows, this.state.room.mapCols);
@@ -81,7 +82,10 @@ export default class GameRoom extends Room<GameRoomState> {
       });
       if (isLobbyLoadingComplete) {
         // 全クライアントの読み込みが完了している場合ゲーム開始
+
+        // 全てのプレイヤーの数を確定しいてから敵を追加
         this.addEnemy();
+        this.state.initializeEnemies();
         this.startGame();
       }
     });
@@ -236,7 +240,7 @@ export default class GameRoom extends Room<GameRoomState> {
 
   // CPU を追加する
   private addEnemy() {
-    const enemyCount = this.state.room.numberOfCpu;
+    const enemyCount = this.state.room.numberOfEnemies;
 
     for (let i = 0; i < enemyCount; i++) {
       const enemy = this.engine.enemyService.addEnemy(`enemy-${i}`);

--- a/backend/src/rooms/schema/Enemy.ts
+++ b/backend/src/rooms/schema/Enemy.ts
@@ -1,8 +1,8 @@
+import { IS_BACKEND_DEBUG } from '../..';
 import * as Constants from '../../constants/constants';
 import { PixelToTile, TileToPixel } from '../../utils/map';
 import Player from './Player';
 import Timer from './Timer';
-import { IS_BACKEND_DEBUG } from '../../index';
 
 export default class Enemy extends Player {
   // 次に移動する座標
@@ -14,6 +14,9 @@ export default class Enemy extends Player {
 
   // 停止するかどうか(デバッグ用)
   freeze: boolean;
+
+  // タイムリミット
+  timeLimitSec!: number;
 
   constructor(sessionId: string, idx: number, name: string = Constants.DEFAULT_PLAYER_NAME) {
     super(sessionId, idx, name);
@@ -105,8 +108,8 @@ export default class Enemy extends Player {
   }
 
   // ゲームの残り時間に応じて、ENEMY_EVALUATION_STEP を返す
-  getStep(timer: Timer): Constants.ENEMY_EVALUATION_STEPS {
-    const gameTime = Constants.TIME_LIMIT_SEC * 1000;
+  getStep(timer: Timer, timeLimitSec: number): Constants.ENEMY_EVALUATION_STEPS {
+    const gameTime = timeLimitSec * 1000;
     switch (true) {
       // 2/3 までの時間帯
       case (gameTime * 2) / 3 < timer.getRemainTime():

--- a/backend/src/rooms/schema/GameMap.ts
+++ b/backend/src/rooms/schema/GameMap.ts
@@ -9,12 +9,14 @@ export default class GameMap extends Schema {
   @type('number')
   cols: number;
 
+  numberOfBlocks: number;
   blockArr: number[]; // 箱（破壊可能）
 
-  constructor() {
+  constructor(row: number, col: number, blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES) {
     super();
-    this.rows = Constants.DEFAULT_TILE_ROWS;
-    this.cols = Constants.DEFAULT_TILE_COLS;
+    this.rows = row;
+    this.cols = col;
+    this.numberOfBlocks = (row - 2) * (col - 2) * blockRate;
     this.blockArr = [];
   }
 
@@ -52,7 +54,7 @@ export default class GameMap extends Schema {
 
     blockPlacements.sort(() => Math.random() - 0.5);
 
-    let maxBlocks = Constants.MAX_BLOCKS;
+    let maxBlocks = this.numberOfBlocks;
     for (const coords of blockPlacements) {
       if (maxBlocks <= 0) break;
       const x = coords[0];

--- a/backend/src/rooms/schema/GameRoomState.ts
+++ b/backend/src/rooms/schema/GameRoomState.ts
@@ -101,7 +101,7 @@ export default class GameRoomState extends Schema {
   }
 
   setTimer() {
-    this.timer.set(Date.now());
+    this.timer.set(Date.now(), this.room.timeLimit);
   }
 
   setGameResult() {

--- a/backend/src/rooms/schema/GameRoomState.ts
+++ b/backend/src/rooms/schema/GameRoomState.ts
@@ -2,6 +2,7 @@ import { MapSchema, Schema, type } from '@colyseus/schema';
 import { faker } from '@faker-js/faker';
 
 import * as Constants from '../../constants/constants';
+import { IGameSettings } from '../../types/gameRoom';
 import GameQueue from '../../utils/gameQueue';
 import { PixelToTile } from '../../utils/map';
 import { generateGameResult } from '../GameResultHandler';
@@ -9,14 +10,18 @@ import Blast from './Blast';
 import Block from './Block';
 import { Bomb } from './Bomb';
 import Enemy from './Enemy';
+import GameMap from './GameMap';
 import GameResult from './GameResult';
 import GameState from './GameState';
 import Item from './Item';
-import GameMap from './GameMap';
 import Player from './Player';
+import Room from './Room';
 import Timer from './Timer';
 
 export default class GameRoomState extends Schema {
+  @type(Room)
+  room!: Room;
+
   @type(GameState)
   gameState: GameState = new GameState();
 
@@ -44,7 +49,23 @@ export default class GameRoomState extends Schema {
 
   readonly enemies: Enemy[] = [];
 
-  @type(GameMap) gameMap = new GameMap();
+  @type(GameMap) gameMap!: GameMap;
+
+  initializeRoom(config: IGameSettings) {
+    this.room = new Room(
+      config.mapRows,
+      config.mapCols,
+      config.numberOfPlayers,
+      config.numberOfCpu,
+      config.blockRate,
+      config.numberOfItems,
+      config.initialHp,
+      config.maxHp,
+      config.timeLimit
+    );
+
+    this.gameMap = new GameMap(this.room.mapRows, this.room.mapCols, this.room.blockRate);
+  }
 
   getPlayer(sessionId: string): Player | undefined {
     return this.players.get(sessionId);

--- a/backend/src/rooms/schema/GameRoomState.ts
+++ b/backend/src/rooms/schema/GameRoomState.ts
@@ -55,13 +55,13 @@ export default class GameRoomState extends Schema {
     this.room = new Room(
       config.mapRows,
       config.mapCols,
-      config.numberOfPlayers,
+      this.players.size,
       config.numberOfEnemies,
       config.blockRate,
       config.numberOfItems,
       config.initialHp,
       config.maxHp,
-      config.timeLimit
+      config.timeLimitSec
     );
 
     this.gameMap = new GameMap(this.room.mapRows, this.room.mapCols, this.room.blockRate);
@@ -101,7 +101,7 @@ export default class GameRoomState extends Schema {
   }
 
   setTimer() {
-    this.timer.set(Date.now(), this.room.timeLimit);
+    this.timer.set(Date.now(), this.room.timeLimitSec);
   }
 
   setGameResult() {

--- a/backend/src/rooms/schema/GameRoomState.ts
+++ b/backend/src/rooms/schema/GameRoomState.ts
@@ -56,7 +56,7 @@ export default class GameRoomState extends Schema {
       config.mapRows,
       config.mapCols,
       config.numberOfPlayers,
-      config.numberOfCpu,
+      config.numberOfEnemies,
       config.blockRate,
       config.numberOfItems,
       config.initialHp,
@@ -65,6 +65,18 @@ export default class GameRoomState extends Schema {
     );
 
     this.gameMap = new GameMap(this.room.mapRows, this.room.mapCols, this.room.blockRate);
+  }
+
+  initializePlayers() {
+    this.players.forEach((player) => {
+      player.initialize(this.room.initialHp, this.room.maxHp, this.room.mapRows, this.room.mapCols);
+    });
+  }
+
+  initializeEnemies() {
+    this.enemies.forEach((enemy) => {
+      enemy.initialize(this.room.initialHp, this.room.maxHp, this.room.mapRows, this.room.mapCols);
+    });
   }
 
   getPlayer(sessionId: string): Player | undefined {

--- a/backend/src/rooms/schema/Player.ts
+++ b/backend/src/rooms/schema/Player.ts
@@ -253,7 +253,7 @@ export default class Player extends Schema {
   // プレイヤーのステータスを最強にする
   debugSetPlayerStatusMax() {
     if (!IS_BACKEND_DEBUG) return;
-    this.hp = Constants.MAX_PLAYER_HP;
+    this.hp = this.maxHp;
     this.speed = Constants.MAX_PLAYER_SPEED;
     this.maxBombCount = Constants.MAX_SETTABLE_BOMB_COUNT;
     this.bombStrength = Constants.MAX_BOMB_STRENGTH;

--- a/backend/src/rooms/schema/Room.ts
+++ b/backend/src/rooms/schema/Room.ts
@@ -1,0 +1,99 @@
+import { Schema, type } from '@colyseus/schema';
+import * as Constants from '../../constants/constants';
+
+export default class Room extends Schema {
+  // マップの行数
+  @type('number')
+  mapRows: number;
+
+  // マップの列数
+  @type('number')
+  mapCols: number;
+
+  // CPUの数
+  @type('string')
+  numberOfCpu: number;
+
+  // ブロックの生成率
+  blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES;
+
+  // アイテムの生成個数
+  numberOfItems: Record<Constants.ITEM_TYPES, number>;
+
+  // ゲーム開始時の初期HP
+  @type('number')
+  initialHp: number;
+
+  // ゲーム中の最大HP
+  maxHp: number;
+
+  // ゲームの制限時間
+  @type('number')
+  timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES;
+
+  constructor(
+    rows: number = Constants.DEFAULT_TILE_ROWS,
+    cols: number = Constants.DEFAULT_TILE_COLS,
+    numberOfPlayer: number,
+    numberOfCpu: number,
+    blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES = Constants.ROOM_INFO_DEFAULT_BLOCK_PLACEMENT_RATE,
+    numberOfItems: Record<Constants.ITEM_TYPES, number> = Constants.ITEM_PLACE_COUNT,
+    initialHp: number = Constants.INITIAL_PLAYER_HP,
+    maxHp: number = Constants.MAX_PLAYER_HP,
+    timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES = Constants.ROOM_INFO_DEFAULT_TIME_LIMIT_SEC
+  ) {
+    super();
+    this.mapRows = rows; // TODO: 何らかの制限を加える
+    this.mapCols = cols; // TODO: 何らかの制限を加える
+    this.numberOfCpu = this.calcNumberOfCpu(numberOfCpu, numberOfPlayer);
+    this.blockRate = blockRate;
+    this.numberOfItems = this.calcNumberOfItems(numberOfItems);
+    this.maxHp = maxHp > Constants.LIMIT_PLAYER_HP ? Constants.LIMIT_PLAYER_HP : maxHp;
+    this.initialHp = this.calcInitialHp(initialHp, maxHp);
+    this.timeLimit = timeLimit;
+  }
+
+  calcNumberOfCpu(numberOfCpu: number, numberOfPlayer: number): number {
+    let result: number;
+
+    // プレイヤーが1人の場合
+    if (numberOfPlayer === 1) {
+      if (numberOfCpu > 0 && numberOfCpu < Constants.MAX_PLAYER - numberOfPlayer) {
+        // 有効な値がセットされてれば、その値を使う
+        result = numberOfCpu;
+      } else {
+        // 空きを全て CPU で埋める
+        result = Constants.MAX_PLAYER - numberOfPlayer;
+      }
+    } else {
+      // 2人の場合はCPUを最低 0人 入れる
+      result = Math.min(Constants.MAX_PLAYER - numberOfPlayer, numberOfCpu);
+    }
+
+    return result;
+  }
+
+  calcNumberOfItems(
+    records: Record<Constants.ITEM_TYPES, number>
+  ): Record<Constants.ITEM_TYPES, number> {
+    const result = Object.create(records);
+    Object.keys(records).forEach((key) => {
+      const itemKey = key as Constants.ITEM_TYPES;
+      result[itemKey] = Math.min(records[itemKey], Constants.ITEM_PLACE_MAX_COUNT_PER_ITEM);
+    });
+
+    return result;
+  }
+
+  calcInitialHp(initialHp: number, maxHp: number): number {
+    if (initialHp > maxHp) {
+      return maxHp;
+    }
+
+    if (initialHp < 0) {
+      return Constants.INITIAL_PLAYER_HP;
+    }
+
+    return initialHp;
+  }
+}

--- a/backend/src/rooms/schema/Room.ts
+++ b/backend/src/rooms/schema/Room.ts
@@ -29,7 +29,7 @@ export default class Room extends Schema {
 
   // ゲームの制限時間
   @type('number')
-  timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES;
+  timeLimitSec: number;
 
   constructor(
     rows: number = Constants.DEFAULT_TILE_ROWS,
@@ -40,7 +40,7 @@ export default class Room extends Schema {
     numberOfItems: Record<Constants.ITEM_TYPES, number> = Constants.ITEM_PLACE_COUNT,
     initialHp: number = Constants.INITIAL_PLAYER_HP,
     maxHp: number = Constants.MAX_PLAYER_HP,
-    timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES = Constants.ROOM_INFO_DEFAULT_TIME_LIMIT_SEC
+    timeLimitSec: number = Constants.DEFAULT_TIME_LIMIT_SEC
   ) {
     super();
     this.mapRows = rows; // TODO: 何らかの制限を加える
@@ -50,7 +50,7 @@ export default class Room extends Schema {
     this.numberOfItems = this.calcNumberOfItems(numberOfItems);
     this.maxHp = maxHp > Constants.LIMIT_PLAYER_HP ? Constants.LIMIT_PLAYER_HP : maxHp;
     this.initialHp = this.calcInitialHp(initialHp, maxHp);
-    this.timeLimit = timeLimit;
+    this.timeLimitSec = timeLimitSec + Constants.GAME_PREPARING_TIME + 1;
   }
 
   calcNumberOfEnemy(numberOfEnemies: number, numberOfPlayers: number): number {

--- a/backend/src/rooms/schema/Room.ts
+++ b/backend/src/rooms/schema/Room.ts
@@ -1,4 +1,5 @@
 import { Schema, type } from '@colyseus/schema';
+
 import * as Constants from '../../constants/constants';
 
 export default class Room extends Schema {
@@ -11,7 +12,6 @@ export default class Room extends Schema {
   mapCols: number;
 
   // CPUの数
-  @type('string')
   numberOfCpu: number;
 
   // ブロックの生成率

--- a/backend/src/rooms/schema/Room.ts
+++ b/backend/src/rooms/schema/Room.ts
@@ -11,8 +11,8 @@ export default class Room extends Schema {
   @type('number')
   mapCols: number;
 
-  // CPUの数
-  numberOfCpu: number;
+  // Enemyの数
+  numberOfEnemies: number;
 
   // ブロックの生成率
   blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES;
@@ -34,8 +34,8 @@ export default class Room extends Schema {
   constructor(
     rows: number = Constants.DEFAULT_TILE_ROWS,
     cols: number = Constants.DEFAULT_TILE_COLS,
-    numberOfPlayer: number,
-    numberOfCpu: number,
+    numberOfPlayers: number,
+    numberOfEnemies: number,
     blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES = Constants.ROOM_INFO_DEFAULT_BLOCK_PLACEMENT_RATE,
     numberOfItems: Record<Constants.ITEM_TYPES, number> = Constants.ITEM_PLACE_COUNT,
     initialHp: number = Constants.INITIAL_PLAYER_HP,
@@ -45,7 +45,7 @@ export default class Room extends Schema {
     super();
     this.mapRows = rows; // TODO: 何らかの制限を加える
     this.mapCols = cols; // TODO: 何らかの制限を加える
-    this.numberOfCpu = this.calcNumberOfCpu(numberOfCpu, numberOfPlayer);
+    this.numberOfEnemies = this.calcNumberOfEnemy(numberOfEnemies, numberOfPlayers);
     this.blockRate = blockRate;
     this.numberOfItems = this.calcNumberOfItems(numberOfItems);
     this.maxHp = maxHp > Constants.LIMIT_PLAYER_HP ? Constants.LIMIT_PLAYER_HP : maxHp;
@@ -53,21 +53,21 @@ export default class Room extends Schema {
     this.timeLimit = timeLimit;
   }
 
-  calcNumberOfCpu(numberOfCpu: number, numberOfPlayer: number): number {
+  calcNumberOfEnemy(numberOfEnemies: number, numberOfPlayers: number): number {
     let result: number;
 
     // プレイヤーが1人の場合
-    if (numberOfPlayer === 1) {
-      if (numberOfCpu > 0 && numberOfCpu < Constants.MAX_PLAYER - numberOfPlayer) {
+    if (numberOfPlayers === 1) {
+      if (numberOfEnemies > 0 && numberOfEnemies < Constants.MAX_PLAYER - numberOfPlayers) {
         // 有効な値がセットされてれば、その値を使う
-        result = numberOfCpu;
+        result = numberOfEnemies;
       } else {
-        // 空きを全て CPU で埋める
-        result = Constants.MAX_PLAYER - numberOfPlayer;
+        // 空きを全て Enemy で埋める
+        result = Constants.MAX_PLAYER - numberOfPlayers;
       }
     } else {
-      // 2人の場合はCPUを最低 0人 入れる
-      result = Math.min(Constants.MAX_PLAYER - numberOfPlayer, numberOfCpu);
+      // 2人の場合はEnemyを最低 0人 入れる
+      result = Math.min(Constants.MAX_PLAYER - numberOfPlayers, numberOfEnemies);
     }
 
     return result;

--- a/backend/src/rooms/schema/Timer.ts
+++ b/backend/src/rooms/schema/Timer.ts
@@ -16,7 +16,7 @@ export default class Timer extends Schema {
   private now!: number;
 
   // 制限時間をセットする
-  set(epochtime: number, timeLimitSec: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES) {
+  set(epochtime: number, timeLimitSec: number) {
     this.startedAt = epochtime;
 
     // 終了時間は開始時間から制限時間を足したもの

--- a/backend/src/rooms/schema/Timer.ts
+++ b/backend/src/rooms/schema/Timer.ts
@@ -16,12 +16,12 @@ export default class Timer extends Schema {
   private now!: number;
 
   // 制限時間をセットする
-  set(epochtime: number) {
+  set(epochtime: number, timeLimitSec: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES) {
     this.startedAt = epochtime;
 
     // 終了時間は開始時間から制限時間を足したもの
     // js ではミリ秒単位で計算するので、1000倍している
-    this.finishedAt = epochtime + Constants.TIME_LIMIT_SEC * 1000;
+    this.finishedAt = epochtime + timeLimitSec * 1000;
 
     this.now = Date.now();
   }

--- a/backend/src/types/gameRoom.d.ts
+++ b/backend/src/types/gameRoom.d.ts
@@ -15,13 +15,12 @@ export interface IGameStartInfo {
 export interface IGameSettings {
   mapRows: number;
   mapCols: number;
-  numberOfPlayers: number;
   numberOfEnemies: number;
   blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES;
   numberOfItems: Record<Constants.ITEM_TYPES, number>;
   initialHp: number;
   maxHp: number;
-  timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES;
+  timeLimitSec: number;
 }
 
 // 全クライアントがゲーム準備完了後に送るデータの型（blocks をJSON形式にシリアライズしたもの）

--- a/backend/src/types/gameRoom.d.ts
+++ b/backend/src/types/gameRoom.d.ts
@@ -15,6 +15,13 @@ export interface IGameStartInfo {
 export interface IGameSettings {
   mapRows: number;
   mapCols: number;
+  numberOfPlayers: number;
+  numberOfCpu: number;
+  blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES;
+  numberOfItems: Record<Constants.ITEM_TYPES, number>;
+  initialHp: number;
+  maxHp: number;
+  timeLimit: Constants.ROOM_INFO_TIME_LIMIT_SEC_TYPES;
 }
 
 // 全クライアントがゲーム準備完了後に送るデータの型（blocks をJSON形式にシリアライズしたもの）

--- a/backend/src/types/gameRoom.d.ts
+++ b/backend/src/types/gameRoom.d.ts
@@ -16,7 +16,7 @@ export interface IGameSettings {
   mapRows: number;
   mapCols: number;
   numberOfPlayers: number;
-  numberOfCpu: number;
+  numberOfEnemies: number;
   blockRate: Constants.ROOM_INFO_BLOCK_PLACEMENT_RATES;
   numberOfItems: Record<Constants.ITEM_TYPES, number>;
   initialHp: number;

--- a/frontend/src/scenes/Game.ts
+++ b/frontend/src/scenes/Game.ts
@@ -53,8 +53,8 @@ export default class Game extends Phaser.Scene {
   private serverTimer?: ServerTimer;
   private room!: Room<GameRoomState>;
 
-  private screenWidth = Constants.DEFAULT_WIDTH;
-  private screenHeight = Constants.DEFAULT_HEIGHT;
+  private screenWidth!: number;
+  private screenHeight!: number;
 
   private cursorKeys!: NavKeys;
   private rows!: number; // サーバから受け取ったマップの行数
@@ -259,13 +259,13 @@ export default class Game extends Phaser.Scene {
   private handleGamePreparingCompleted() {
     this.tweens.add({
       targets: this.upTitle,
-      x: -Constants.DEFAULT_WIDTH,
+      x: -this.screenWidth,
       duration: 300,
       ease: Phaser.Math.Easing.Quadratic.In,
     });
     this.tweens.add({
       targets: this.downTitle,
-      x: Constants.DEFAULT_WIDTH * 2,
+      x: this.screenWidth * 2,
       duration: 300,
       ease: Phaser.Math.Easing.Quadratic.In,
     });

--- a/frontend/src/scenes/GameHeader.ts
+++ b/frontend/src/scenes/GameHeader.ts
@@ -40,11 +40,6 @@ export default class GameHeader extends Phaser.Scene {
     this.player = getGameScene().getCurrentPlayer();
 
     this.startTimer = false;
-    this.textTimer = this.createText(
-      0,
-      5,
-      convertSecondsToMMSS(Constants.TIME_LIMIT_SEC - Constants.GAME_PREPARING_TIME - 1)
-    );
     this.textHp = this.createText(150, 5, `HP:${this.player.getHP()}`);
     this.textBombCount = this.createText(350, 5, `×${this.player.getItemCountOfBombCount()}`);
     this.textBombStrength = this.createText(500, 5, `×${this.player.getItemCountOfBombStrength()}`);
@@ -75,7 +70,15 @@ export default class GameHeader extends Phaser.Scene {
     if (network == null) return;
     this.network = data.network;
     this.serverTimer = serverTimer;
-
+    this.textTimer = this.createText(
+      0,
+      5,
+      convertSecondsToMMSS(
+        (this.serverTimer.finishedAt - this.serverTimer.startedAt) / 1000 -
+          Constants.GAME_PREPARING_TIME -
+          1
+      )
+    );
     gameEvents.on(Event.GAME_PREPARING_COMPLETED, () => (this.startTimer = true));
   }
 

--- a/frontend/src/scenes/Lobby.ts
+++ b/frontend/src/scenes/Lobby.ts
@@ -1,29 +1,19 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import * as Config from '../config/config';
-import * as Constants from '../../../backend/src/constants/constants';
-import Network from '../services/Network';
-import {
-  createButton,
-  createButtons,
-  createDialog,
-  createGridTable,
-  flipPlayerCard,
-} from '../utils/ui';
-import ServerPlayer from '../../../backend/src/rooms/schema/Player';
-import GridTable from 'phaser3-rex-plugins/templates/ui/gridtable/GridTable';
-import Dialog from 'phaser3-rex-plugins/templates/ui/dialog/Dialog';
-import GridSizer from 'phaser3-rex-plugins/templates/ui/gridsizer/GridSizer';
-import Label from 'phaser3-rex-plugins/templates/ui/label/Label';
 import ContainerLite from 'phaser3-rex-plugins/plugins/containerlite';
 import Buttons from 'phaser3-rex-plugins/templates/ui/buttons/Buttons';
+import Dialog from 'phaser3-rex-plugins/templates/ui/dialog/Dialog';
+import GridSizer from 'phaser3-rex-plugins/templates/ui/gridsizer/GridSizer';
+import GridTable from 'phaser3-rex-plugins/templates/ui/gridtable/GridTable';
+import Label from 'phaser3-rex-plugins/templates/ui/label/Label';
+
+import * as Constants from '../../../backend/src/constants/constants';
+import ServerPlayer from '../../../backend/src/rooms/schema/Player';
+import { IGameData, IGameSettings, IGameStartInfo, ISerializedGameData } from '../../../backend/src/types/gameRoom';
+import * as Config from '../config/config';
+import Network from '../services/Network';
 import { isPlay } from '../utils/sound';
 import { addBackground } from '../utils/title';
-import {
-  ISerializedGameData,
-  IGameSettings,
-  IGameStartInfo,
-  IGameData,
-} from '../../../backend/src/types/gameRoom';
+import { createButton, createButtons, createDialog, createGridTable, flipPlayerCard } from '../utils/ui';
 
 export interface IAvailableRoom {
   id: string;
@@ -100,9 +90,16 @@ export default class Lobby extends Phaser.Scene {
   private initGameData() {
     this.gameData = { blocks: undefined, mapRows: undefined, mapCols: undefined };
     // TODO: UI で動的に変更でき、他のクライアントが値を変更した時に更新する
+
     this.gameSettings = {
       mapRows: Constants.DEFAULT_TILE_ROWS, // ここを変更することでルームのマップの幅・高さを設定できる
       mapCols: Constants.DEFAULT_TILE_COLS,
+      numberOfEnemies: 1, // TODO:
+      numberOfItems: Constants.ITEM_PLACE_COUNT,
+      blockRate: 0.5, // TODO:
+      initialHp: 2, // TODO:
+      maxHp: 10, // TODO
+      timeLimitSec: 60, // TODO
     };
   }
 

--- a/frontend/src/scenes/Preloader.ts
+++ b/frontend/src/scenes/Preloader.ts
@@ -3,14 +3,14 @@ import Phaser from 'phaser';
 import * as Constants from '../../../backend/src/constants/constants';
 import { createBombAnims, createPenetrationBombAnims } from '../anims/BombAnims';
 import { createCharacterAnims } from '../anims/CharacterAnims';
-import { createExplodeAnims, createPenetrationExplodeAnims } from '../anims/explodeAnims';
-import { createTrophyAnims } from '../anims/TrophyAnims';
 import { createCurtainOpenAnims } from '../anims/CurtainAnims';
+import { createExplodeAnims, createPenetrationExplodeAnims } from '../anims/explodeAnims';
+import { createMapAnims } from '../anims/MapAnims';
+import { createTitleBackgroundAnims } from '../anims/TitleBackground';
+import { createTrophyAnims } from '../anims/TrophyAnims';
 import * as Config from '../config/config';
 import Network from '../services/Network';
 import isMobile from '../utils/mobile';
-import { createMapAnims } from '../anims/MapAnims';
-import { createTitleBackgroundAnims } from '../anims/TitleBackground';
 
 export default class Preloader extends Phaser.Scene {
   private preloadComplete = false;

--- a/frontend/src/utils/debug_menu.ts
+++ b/frontend/src/utils/debug_menu.ts
@@ -5,8 +5,8 @@ import * as Constants from '../../../backend/src/constants/constants';
 export function addDebugMenu(scene: Phaser.Scene): GridTable {
   return scene.rexUI.add
     .gridTable({
-      x: Constants.DEFAULT_WIDTH / 2,
-      y: Constants.DEFAULT_HEIGHT / 5 + 300,
+      x: scene.cameras.main.width / 2,
+      y: scene.cameras.main.height / 5 + 300,
       width: 400,
       height: 400,
       scrollMode: 0,


### PR DESCRIPTION
クライアントでこの辺の値をセットした時に、
サーバ側でハンドリングして設定できるようにした。

```ts
    this.gameSettings = {
      mapRows: Constants.DEFAULT_TILE_ROWS, // ここを変更することでルームのマップの幅・高さを設定できる
      mapCols: Constants.DEFAULT_TILE_COLS,
      numberOfEnemies: 1, // TODO:
      numberOfItems: Constants.ITEM_PLACE_COUNT,
      blockRate: 0.5, // TODO:
      initialHp: 2, // TODO:
      maxHp: 10, // TODO
      timeLimitSec: 60, // TODO
    };
```